### PR TITLE
Enable to serialize null relations closes #10

### DIFF
--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -102,6 +102,9 @@ class Relationship(BaseRelationship):
         dict_class = self.parent.dict_class if self.parent else dict
         ret = dict_class()
         ret[attr] = dict_class()
+        if value is None:
+            ret[attr] = [] if self.many else None
+            return ret
         ret[attr]['links'] = dict_class()
         self_url = self.get_self_url(obj)
         if self_url:
@@ -111,4 +114,5 @@ class Relationship(BaseRelationship):
             ret[attr]['links']['related'] = related_url
         if self.include_data:
             ret[attr]['data'] = self.add_resource_linkage(value)
+
         return ret

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -102,9 +102,6 @@ class Relationship(BaseRelationship):
         dict_class = self.parent.dict_class if self.parent else dict
         ret = dict_class()
         ret[attr] = dict_class()
-        if value is None:
-            ret[attr] = [] if self.many else None
-            return ret
         ret[attr]['links'] = dict_class()
         self_url = self.get_self_url(obj)
         if self_url:
@@ -113,6 +110,10 @@ class Relationship(BaseRelationship):
         if related_url:
             ret[attr]['links']['related'] = related_url
         if self.include_data:
-            ret[attr]['data'] = self.add_resource_linkage(value)
+            if value is None:
+                ret[attr]['data'] = [] if self.many else None
+            else:
+                ret[attr]['data'] = self.add_resource_linkage(value)
+        return ret
 
         return ret

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,10 @@ from tests.base import Author, Post, Comment, fake
 
 def make_author():
     return Author(id=fake.random_int(), first_name=fake.first_name(),
-                    last_name=fake.last_name(), twitter=fake.domain_word())
+                  last_name=fake.last_name(), twitter=fake.domain_word())
 
 def make_post(with_comments=True, with_author=True):
-    comments = [make_comment() for _ in range(2)] if with_comments else None
+    comments = [make_comment() for _ in range(2)] if with_comments else []
     author = make_author() if with_author else None
     return Post(
         id=fake.random_int(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,9 @@ def make_author():
     return Author(id=fake.random_int(), first_name=fake.first_name(),
                     last_name=fake.last_name(), twitter=fake.domain_word())
 
-def make_post():
-    comments = [make_comment() for _ in range(2)]
-    author = make_author()
+def make_post(with_comments=True, with_author=True):
+    comments = [make_comment() for _ in range(2)] if with_comments else None
+    author = make_author() if with_author else None
     return Post(
         id=fake.random_int(),
         title=fake.catch_phrase(),
@@ -30,3 +30,11 @@ def authors():
 @pytest.fixture()
 def post():
     return make_post()
+
+@pytest.fixture()
+def post_with_null_comment():
+    return make_post(with_comments=False)
+
+@pytest.fixture()
+def post_with_null_author():
+    return make_post(with_author=False)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -38,8 +38,8 @@ class TestGenericRelationshipField:
 
     def test_include_data_single(self, post):
         field = Relationship(
-            related_url='/authors/{author_id}',
-            related_url_kwargs={'author_id': '<author.id>'},
+            related_url='/posts/{post_id}/author/',
+            related_url_kwargs={'post_id': '<id>'},
             include_data=True, type_='people'
         )
         result = field.serialize('author', post)
@@ -62,12 +62,13 @@ class TestGenericRelationshipField:
 
     def test_include_null_data_single(self, post_with_null_author):
         field = Relationship(
-            related_url='/authors/{author_id}',
-            related_url_kwargs={'author_id': '<author.id>'},
+            related_url='posts/{post_id}/author',
+            related_url_kwargs={'post_id': '<id>'},
             include_data=True, type_='people'
         )
         result = field.serialize('author', post_with_null_author)
-        assert result['author'] == None
+        assert result['author'] and result['author']['links']['related']
+        assert result['author']['data'] == None
 
     def test_include_null_data_many(self, post_with_null_comment):
         field = Relationship(
@@ -76,7 +77,18 @@ class TestGenericRelationshipField:
             many=True, include_data=True, type_='comments'
         )
         result = field.serialize('comments', post_with_null_comment)
-        assert result['comments'] == []
+        assert result['comments'] and result['comments']['links']['related']
+        assert result['comments']['data'] == []
+
+    def test_exclude_data(self, post_with_null_comment):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=True, include_data=False, type_='comments'
+        )
+        result = field.serialize('comments', post_with_null_comment)
+        assert result['comments'] and result['comments']['links']['related']
+        assert 'data' not in result['comments']
 
     def test_is_dump_only_by_default(self):
         field = Relationship(

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -60,6 +60,24 @@ class TestGenericRelationshipField:
         ids = [each['id'] for each in result['comments']['data']]
         assert ids == [each.id for each in post.comments]
 
+    def test_include_null_data_single(self, post_with_null_author):
+        field = Relationship(
+            related_url='/authors/{author_id}',
+            related_url_kwargs={'author_id': '<author.id>'},
+            include_data=True, type_='people'
+        )
+        result = field.serialize('author', post_with_null_author)
+        assert result['author'] == None
+
+    def test_include_null_data_many(self, post_with_null_comment):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=True, include_data=True, type_='comments'
+        )
+        result = field.serialize('comments', post_with_null_comment)
+        assert result['comments'] == []
+
     def test_is_dump_only_by_default(self):
         field = Relationship(
             'http://example.com/posts/{id}/comments',


### PR DESCRIPTION
Hi @sloria 

this is neither of the PR's I've promised you lately... but this one was more urgent for me :wink: 

I testing this out in a flask application, and the null relationship fields in the json are simply missing. So while it seems this patch is OK, the desired result for a schema dump is not complete.

I think we need to add a test to `test_schema.py` for serializing relatonships, including null relationship and then deal with why the objects are not being serialized properly with null relationship. 

I looked around, seems like marshmallow-jsonapi.schema.format_item() does some magic with dict.update, which I think may be the cause. I suspect using {} instead of the jsonapi standards for empty relationships might be work with the given format_item, looks like it might give an empty collection for the relationship.

Any suggestions? 
