### PR TITLE
Add support for automatic self-linking

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors (chronological)
 ============================
 
 - Jotham Apaloo `@jo-tham <https://github.com/jo-tham>`_
+- Anders Steinlein `@asteinlein <https://github.com/asteinlein>`_

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -16,6 +16,13 @@ A `Schema` **MUST** define:
 
 It is **RECOMMENDED** to set strict mode to `True`.
 
+Automatic self-linking is supported through these Meta options:
+
+- ``self_url`` specifies the URL to the resource itself
+- ``self_url_kwargs`` specifies replacement fields for `self_url`
+- ``self_url_many`` specifies the URL the resource when a collection (many) are
+  serialized
+
 .. code-block:: python
 
     from marshmallow_jsonapi import Schema, fields
@@ -26,6 +33,9 @@ It is **RECOMMENDED** to set strict mode to `True`.
 
         class Meta:
             type_ = 'articles'
+            self_url = '/articles/{id}'
+            self_url_kwargs = {'id': '<id>'}
+            self_url_many = '/articles/'
             strict = True
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -262,7 +262,7 @@ class TestInflection:
         assert data['last_name'] == 'Loria'
 
 
-class TestAutpSelfUrls:
+class TestAutoSelfUrls:
     class AuthorAutoSelfLinkSchema(Schema):
         id = fields.Int(dump_only=True)
         first_name = fields.Str(required=True)


### PR DESCRIPTION
This works through the new Meta options `self_url`, `self_url_kwargs`
and `self_url_many`. Specifying these will add a link object with a self
link to the top-level and each resource.

Tests and documentation updates are included, as are a new
AUTHORS.rst-file to comply the with contribution guidelines.

This is just the first in a series of patches I plan on doing. A
Flask-integration variant of this is planned similar to the Flask version
of the relationship field. Additionally, my plan is to extend the
relationship field to support linking to another schema class, thus
inferring the self-links for the relationship as provided by this patch
instead of having to define them on the relationship definition itself.
