### PR TITLE
FlaskRelationship: handle `BuildError` for empty relationship on url generation

### DIFF
--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -102,13 +102,16 @@ class Relationship(BaseRelationship):
         dict_class = self.parent.dict_class if self.parent else dict
         ret = dict_class()
         ret[attr] = dict_class()
-        ret[attr]['links'] = dict_class()
+
         self_url = self.get_self_url(obj)
-        if self_url:
-            ret[attr]['links']['self'] = self_url
         related_url = self.get_related_url(obj)
-        if related_url:
-            ret[attr]['links']['related'] = related_url
+        if self_url or related_url:
+            ret[attr]['links'] = dict_class()
+            if self_url:
+                ret[attr]['links']['self'] = self_url
+            if related_url:
+                ret[attr]['links']['related'] = related_url
+
         if self.include_data:
             if value is None:
                 ret[attr]['data'] = [] if self.many else None

--- a/marshmallow_jsonapi/flask.py
+++ b/marshmallow_jsonapi/flask.py
@@ -3,6 +3,8 @@
 from __future__ import absolute_import
 
 import flask
+from werkzeug.routing import BuildError
+
 from .fields import Relationship as GenericRelationship
 from .utils import resolve_params
 
@@ -52,7 +54,12 @@ class Relationship(GenericRelationship):
         if view_name:
             kwargs = resolve_params(obj, view_kwargs)
             kwargs['endpoint'] = view_name
-            return flask.url_for(**kwargs)
+            try:
+                return flask.url_for(**kwargs)
+            except BuildError:
+                if None in kwargs.values():  # most likely to be caused by empty relationship
+                    return None
+                raise
         return None
 
     def get_related_url(self, obj):

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from flask import Flask, url_for
 import pytest
+from werkzeug.routing import BuildError
 
 from marshmallow_jsonapi.flask import Relationship
 
@@ -69,3 +70,20 @@ class TestRelationshipField:
         assert 'comments' in result
         related = result['comments']['links']['self']
         assert related == url_for('posts_comments', post_id=post.id)
+
+    def test_empty_relationship(self, app, post_with_null_author):
+        field = Relationship(
+            related_view='author_detail',
+            related_view_kwargs={'author_id': '<author>'}
+        )
+        result = field.serialize('author', post_with_null_author)
+
+        assert not result['author']['links']
+
+    def test_non_existing_view(self, app, post):
+        field = Relationship(
+            related_view='non_existing_view',
+            related_view_kwargs={'author_id': '<author>'}
+        )
+        with pytest.raises(BuildError):
+            field.serialize('author', post)

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -78,7 +78,7 @@ class TestRelationshipField:
         )
         result = field.serialize('author', post_with_null_author)
 
-        assert not result['author']['links']
+        assert not result['author']
 
     def test_non_existing_view(self, app, post):
         field = Relationship(


### PR DESCRIPTION
This should resolve issue #24.
