### PR TITLE
Support loading 'id' from relationships

### DIFF
--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -71,6 +71,8 @@ class Relationship(BaseRelationship):
         self.id_field = id_field or self.id_field
         super(Relationship, self).__init__(**kwargs)
         self.dump_only = kwargs.pop('dump_only', True)
+        if many and not self.dump_only:
+            raise ValueError('Loading is not supported for many=True.')
 
     def get_related_url(self, obj):
         if self.related_url:

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -107,6 +107,14 @@ class Schema(ma.Schema):
             raise IncorrectTypeError(actual=item['type'], expected=self.opts.type_)
         if 'attributes' not in item:
             raise ma.ValidationError('`data` object must include `attributes` key.')
+        relationships = item.get('relationships')
+        if not relationships:
+            return item['attributes']
+        # TODO: python2?
+        for field, relationship_obj in relationships.items():
+            if 'data' not in relationship_obj:
+                raise ma.ValidationError('Relationship members must include \'data\' key')
+            item['attributes'][field] = relationship_obj['data']['id']
         return item['attributes']
 
     @ma.pre_load(pass_many=True)

--- a/marshmallow_jsonapi/validate.py
+++ b/marshmallow_jsonapi/validate.py
@@ -1,0 +1,25 @@
+from marshmallow.validate import Validator, ValidationError
+
+class ForeignKey(Validator):
+    """Validator which succeeds if the value it is passed is positive integer.
+    """
+
+    message_all = 'Must be and integer and greater than 0.'
+
+    def __init__(self, error=None):
+        self.min = 0
+        self.error = error
+
+    def _format_error(self, value, message):
+        return (self.error or message).format(input=value)
+
+    def __call__(self, value):
+        if value < 1:
+            message = self.message_all
+            raise ValidationError(self._format_error(value, message))
+
+        if not isinstance(value, int):
+            message = self.message_all
+            raise ValidationError(self._format_error(value, message))
+
+        return value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,26 @@ def make_post(with_comments=True, with_author=True):
         author=author,
         comments=comments)
 
+def make_post_document(with_comments=True, with_author=True):
+    doc = {
+        'type': 'posts',
+        'id': fake.random_int(),
+        'attributes': {
+            'title': fake.catch_phrase()
+        },
+        'relationships': {}
+    }
+    if with_comments:
+        doc['relationships']['comments'] = [
+          { 'type': 'comments', 'id': '5' },
+          { 'type': 'comments', 'id': '12' }
+        ]
+    if with_author:
+        doc['relationships']['author'] = {
+                'data': { 'type': 'people', 'id': 9 }
+            }
+    return {'data': doc}
+
 def make_comment():
     return Comment(id=fake.random_int(), body=fake.bs())
 
@@ -38,3 +58,7 @@ def post_with_null_comment():
 @pytest.fixture()
 def post_with_null_author():
     return make_post(with_author=False)
+
+@pytest.fixture()
+def post_document():
+    return make_post_document(with_comments=False)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -92,7 +92,37 @@ class TestGenericRelationshipField:
 
     def test_is_dump_only_by_default(self):
         field = Relationship(
-            'http://example.com/posts/{id}/comments',
+            related_url='http://example.com/posts/{id}/comments',
             related_url_kwargs={'id': '<id>'}
         )
         assert field.dump_only is True
+
+    def test_deserialize_relationship_single(self):
+        field = Relationship(
+            related_url='/posts/{post_id}/author/',
+            related_url_kwargs={'post_id': '<id>'},
+            include_data=True, type_='people'
+        )
+        val = 1
+        result = field.deserialize(val)
+        assert result == val
+
+    def test_deserialize_relationship_many(self):
+        with pytest.raises(ValueError) as excinfo:
+            Relationship(
+                related_url='/posts/{post_id}/comments',
+                related_url_kwargs={'post_id': '<id>'},
+                many=True, include_data=False, type_='comments',
+                dump_only=False
+            )
+        assert excinfo.value.args[0] == 'Loading is not supported for many=True.'
+
+    def test_deserialize_null_relationship(self):
+        field = Relationship(
+            related_url='/posts/{post_id}/author/',
+            related_url_kwargs={'post_id': '<id>'},
+            include_data=True, type_='people', missing=None,
+        )
+        val = None
+        result = field.deserialize(val)
+        assert result == val


### PR DESCRIPTION
Hi @sloria 
here's a sketch for loading data from relationships.
- Retrieve relationship in _unwrap item
- Raise ValueError from relationship field if many=True and not dump_only (i.e. deserializing the to-many side of a relationship probably does not make sense for use with an ORM - could be added in the future, though)
- Added schema and field level tests
- Add basic foreign key field validator

I want to add something to the docs, but wanted to get your feedback before going further.
