### PR TITLE
Added relationship deserialization

### DIFF
--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -100,28 +100,27 @@ class Relationship(BaseRelationship):
             }
         return included_data
 
-    def validate_data_object(self, relationship):
+    def validate_data_object(self, data):
         errors = []
-        if 'id' not in relationship:
+        if 'id' not in data:
             errors.append('Must have an `id` field')
-        if 'type' not in relationship:
+        if 'type' not in data:
             errors.append('Must have a `type` field')
-        elif relationship['type'] != self.type_:
+        elif data['type'] != self.type_:
             errors.append('Invalid `type` specified')
 
         if errors:
             raise ValidationError(errors)
 
     def _deserialize(self, value, attr, obj):
-        if 'data' not in value:
-            return None
+        data = value.get('data')
+        if not data:
+            return data
 
         if self.many:
-            data = value.get('data', [])
             for item in data:
                 self.validate_data_object(item)
         else:
-            data = value.get('data', {})
             self.validate_data_object(data)
 
         if self.many:

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -100,6 +100,8 @@ class Relationship(BaseRelationship):
         return included_data
 
     def validate_type(self, relationship):
+        if 'id' not in relationship:
+            raise ValueError('Must have an `id` field')
         if 'type' not in relationship:
             raise ValueError('Must have a `type` field')
         if relationship['type'] != self.type_:

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -113,6 +113,9 @@ class Relationship(BaseRelationship):
             raise ValidationError(errors)
 
     def _deserialize(self, value, attr, obj):
+        if 'data' not in value:
+            return None
+
         if self.many:
             data = value.get('data', [])
             for item in data:

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -100,7 +100,7 @@ class Relationship(BaseRelationship):
             }
         return included_data
 
-    def validate_type(self, relationship):
+    def validate_data_object(self, relationship):
         errors = []
         if 'id' not in relationship:
             errors.append('Must have an `id` field')
@@ -116,10 +116,10 @@ class Relationship(BaseRelationship):
         if self.many:
             data = value.get('data', [])
             for item in data:
-                self.validate_type(item)
+                self.validate_data_object(item)
         else:
             data = value.get('data', {})
-            self.validate_type(data)
+            self.validate_data_object(data)
 
         if self.many:
             return [item.get('id') for item in data]

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -2,6 +2,7 @@
 """Includes all the fields classes from `marshmallow.fields` as well as
 fields for serializing JSON API-formatted hyperlinks.
 """
+from marshmallow import ValidationError
 # Make core fields importable from marshmallow_jsonapi
 from marshmallow.fields import *  # noqa
 
@@ -100,12 +101,16 @@ class Relationship(BaseRelationship):
         return included_data
 
     def validate_type(self, relationship):
+        errors = []
         if 'id' not in relationship:
-            raise ValueError('Must have an `id` field')
+            errors.append('Must have an `id` field')
         if 'type' not in relationship:
-            raise ValueError('Must have a `type` field')
-        if relationship['type'] != self.type_:
-            raise ValueError('Invalid `type` specified')
+            errors.append('Must have a `type` field')
+        elif relationship['type'] != self.type_:
+            errors.append('Invalid `type` specified')
+
+        if errors:
+            raise ValidationError(errors)
 
     def _deserialize(self, value, attr, obj):
         if self.many:

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -114,7 +114,7 @@ class Relationship(BaseRelationship):
 
     def _deserialize(self, value, attr, obj):
         data = value.get('data')
-        if not data:
+        if data is None or data == []:
             return data
 
         if self.many:

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -113,8 +113,11 @@ class Relationship(BaseRelationship):
             raise ValidationError(errors)
 
     def _deserialize(self, value, attr, obj):
+        if 'data' not in value:
+            raise ValidationError('Must include a `data` key')
+
         data = value.get('data')
-        if data is None or data == []:
+        if data is None or value['data'] == []:
             return data
 
         if self.many:

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -72,7 +72,6 @@ class Relationship(BaseRelationship):
         self.type_ = type_
         self.id_field = id_field or self.id_field
         super(Relationship, self).__init__(**kwargs)
-        self.dump_only = kwargs.pop('dump_only', True)
 
     def get_related_url(self, obj):
         if self.related_url:

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -182,14 +182,16 @@ class Schema(ma.Schema):
 
         See: http://jsonapi.org/format/#error-objects
         """
-        if index:
-            pointer = '/data/{index}/attributes/{field_name}'.format(
-                index=index, field_name=self.inflect(field_name)
-            )
+        if isinstance(self.declared_fields.get(field_name), BaseRelationship):
+            container = 'relationships'
         else:
-            pointer = '/data/attributes/{field_name}'.format(
-                field_name=self.inflect(field_name)
-            )
+            container = 'attributes'
+
+        inflected_name = self.inflect(field_name)
+        if index:
+            pointer = '/data/{}/{}/{}'.format(index, container, inflected_name)
+        else:
+            pointer = '/data/{}/{}'.format(container, inflected_name)
         return {
             'detail': message,
             'source': {

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -109,9 +109,9 @@ class Schema(ma.Schema):
             raise ma.ValidationError('`data` object must include `attributes` key.')
 
         payload = self.dict_class()
-        for key, value in item.get('attributes', {}).iteritems():
+        for key, value in iteritems(item.get('attributes', {})):
             payload[key] = value
-        for key, value in item.get('relationships', {}).iteritems():
+        for key, value in iteritems(item.get('relationships', {})):
             payload[key] = value
         return payload
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -114,14 +114,23 @@ class TestGenericRelationshipField:
             field.deserialize(value)
         assert excinfo.value.args[0] == ['Invalid `type` specified']
 
-    def test_deserialize_missing_data_node(self, post):
+    def test_deserialize_null_data_node(self, post):
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
             many=False, include_data=False, type_='comments'
         )
-        result = field.deserialize({})
+        result = field.deserialize({'data': None})
         assert result is None
+
+    def test_deserialize_empty_data_node(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=False, include_data=False, type_='comments'
+        )
+        result = field.deserialize({'data': []})
+        assert result == []
 
     def test_include_null_data_single(self, post_with_null_author):
         field = Relationship(

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -114,7 +114,7 @@ class TestGenericRelationshipField:
             field.deserialize(value)
         assert excinfo.value.args[0] == ['Invalid `type` specified']
 
-    def test_deserialize_null_data_node(self, post):
+    def test_deserialize_null_data_value(self, post):
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
@@ -123,7 +123,7 @@ class TestGenericRelationshipField:
         result = field.deserialize({'data': None})
         assert result is None
 
-    def test_deserialize_empty_data_node(self, post):
+    def test_deserialize_empty_data_list(self, post):
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
@@ -131,6 +131,17 @@ class TestGenericRelationshipField:
         )
         result = field.deserialize({'data': []})
         assert result == []
+
+    def test_deserialize_empty_data_node(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=False, include_data=False, type_='comments'
+        )
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize({'data': {}})
+        assert excinfo.value.args[0] == [
+            'Must have an `id` field', 'Must have a `type` field']
 
     def test_include_null_data_single(self, post_with_null_author):
         field = Relationship(

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from marshmallow import ValidationError
 from marshmallow_jsonapi.fields import Relationship
 
 
@@ -86,10 +87,10 @@ class TestGenericRelationshipField:
             related_url_kwargs={'post_id': '<id>'},
             many=False, include_data=True, type_='comments'
         )
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValidationError) as excinfo:
             value = {'data': {'type': 'comments'}}
             field.deserialize(value)
-        assert excinfo.value.args[0] == 'Must have an `id` field'
+        assert excinfo.value.args[0] == ['Must have an `id` field']
 
     def test_deserialize_data_missing_type(self, post):
         field = Relationship(
@@ -97,10 +98,10 @@ class TestGenericRelationshipField:
             related_url_kwargs={'post_id': '<id>'},
             many=False, include_data=True, type_='comments'
         )
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValidationError) as excinfo:
             value = {'data': {'id': '1'}}
             field.deserialize(value)
-        assert excinfo.value.args[0] == 'Must have a `type` field'
+        assert excinfo.value.args[0] == ['Must have a `type` field']
 
     def test_deserialize_data_incorrect_type(self, post):
         field = Relationship(
@@ -108,10 +109,10 @@ class TestGenericRelationshipField:
             related_url_kwargs={'post_id': '<id>'},
             many=False, include_data=True, type_='comments'
         )
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValidationError) as excinfo:
             value = {'data': {'type': 'posts', 'id': '1'}}
             field.deserialize(value)
-        assert excinfo.value.args[0] == 'Invalid `type` specified'
+        assert excinfo.value.args[0] == ['Invalid `type` specified']
 
     def test_include_null_data_single(self, post_with_null_author):
         field = Relationship(

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -143,6 +143,16 @@ class TestGenericRelationshipField:
         assert excinfo.value.args[0] == [
             'Must have an `id` field', 'Must have a `type` field']
 
+    def test_deserialize_empty_relationship_node(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=False, include_data=False, type_='comments'
+        )
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize({})
+        assert excinfo.value.args[0] == 'Must include a `data` key'
+
     def test_include_null_data_single(self, post_with_null_author):
         field = Relationship(
             related_url='posts/{post_id}/author',

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -114,6 +114,15 @@ class TestGenericRelationshipField:
             field.deserialize(value)
         assert excinfo.value.args[0] == ['Invalid `type` specified']
 
+    def test_deserialize_missing_data_node(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=False, include_data=False, type_='comments'
+        )
+        result = field.deserialize({})
+        assert result is None
+
     def test_include_null_data_single(self, post_with_null_author):
         field = Relationship(
             related_url='posts/{post_id}/author',

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -182,10 +182,3 @@ class TestGenericRelationshipField:
         result = field.serialize('comments', post_with_null_comment)
         assert result['comments'] and result['comments']['links']['related']
         assert 'data' not in result['comments']
-
-    def test_is_dump_only_by_default(self):
-        field = Relationship(
-            'http://example.com/posts/{id}/comments',
-            related_url_kwargs={'id': '<id>'}
-        )
-        assert field.dump_only is True

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -80,6 +80,17 @@ class TestGenericRelationshipField:
         result = field.deserialize(value)
         assert result == ['1']
 
+    def test_deserialize_data_missing_id(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=False, include_data=True, type_='comments'
+        )
+        with pytest.raises(ValueError) as excinfo:
+            value = {'data': {'type': 'comments'}}
+            field.deserialize(value)
+        assert excinfo.value.args[0] == 'Must have an `id` field'
+
     def test_deserialize_data_missing_type(self, post):
         field = Relationship(
             related_url='/posts/{post_id}/comments',

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -60,6 +60,48 @@ class TestGenericRelationshipField:
         ids = [each['id'] for each in result['comments']['data']]
         assert ids == [each.id for each in post.comments]
 
+    def test_deserialize_data_single(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=False, include_data=True, type_='comments'
+        )
+        value = {'data': {'type': 'comments', 'id': '1'}}
+        result = field.deserialize(value)
+        assert result == '1'
+
+    def test_deserialize_data_many(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=True, include_data=True, type_='comments'
+        )
+        value = {'data': [{'type': 'comments', 'id': '1'}]}
+        result = field.deserialize(value)
+        assert result == ['1']
+
+    def test_deserialize_data_missing_type(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=False, include_data=True, type_='comments'
+        )
+        with pytest.raises(ValueError) as excinfo:
+            value = {'data': {'id': '1'}}
+            field.deserialize(value)
+        assert excinfo.value.args[0] == 'Must have a `type` field'
+
+    def test_deserialize_data_incorrect_type(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=False, include_data=True, type_='comments'
+        )
+        with pytest.raises(ValueError) as excinfo:
+            value = {'data': {'type': 'posts', 'id': '1'}}
+            field.deserialize(value)
+        assert excinfo.value.args[0] == 'Invalid `type` specified'
+
     def test_include_null_data_single(self, post_with_null_author):
         field = Relationship(
             related_url='posts/{post_id}/author',
@@ -68,7 +110,7 @@ class TestGenericRelationshipField:
         )
         result = field.serialize('author', post_with_null_author)
         assert result['author'] and result['author']['links']['related']
-        assert result['author']['data'] == None
+        assert result['author']['data'] is None
 
     def test_include_null_data_many(self, post_with_null_comment):
         field = Relationship(

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -54,13 +54,6 @@ class TestRelationshipField:
             )
         assert excinfo.value.args[0] == 'include_data=True requires the type_ argument.'
 
-    def test_is_dump_only_by_default(self):
-        field = Relationship(
-            related_view='author_detail',
-            related_view_kwargs={'author_id': '<id>'}
-        )
-        assert field.dump_only is True
-
     def test_serialize_self_link(self, app, post):
         field = Relationship(
             self_view='posts_comments',


### PR DESCRIPTION
Adds support for deserializing `to-one` and `to-many` relationships.

Fields are deserialized based on the value of the `many` attribute.  `id` and `type` values are required[1].  Supplied type values are validated against the `type_` attribute.  The `id` field can be validated by specifying additional validators on the `validate` attribute.

``` json
// to-one
{"data": {"type": "comments", "id": "1"}}
// deserializes to
"1"

// to-many
{"data": [{"type": "comments", "id": "1"}]}
// deserializes to
["1"]
```
1. http://jsonapi.org/format/#document-resource-object-linkage
