### PR TITLE
Relationship id's serialize to strings

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Contributors (chronological)
 - Jotham Apaloo `@jo-tham <https://github.com/jo-tham>`_
 - Anders Steinlein `@asteinlein <https://github.com/asteinlein>`_
 - `@floqqi <https://github.com/floqqi>`_
+- Colton Allen `@cmanallen <https://github.com/cmanallen>`_

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -85,16 +85,20 @@ class Relationship(BaseRelationship):
         return None
 
     def add_resource_linkage(self, value):
+        def stringify(value):
+            if value is not None:
+                return str(value)
+            return value
+
         if self.many:
-            included_data = [
-                {'type': self.type_,
-                    'id': get_value_or_raise(self.id_field, each)}
-                for each in value
-            ]
+            included_data = [{
+                'type': self.type_,
+                'id': stringify(get_value_or_raise(self.id_field, each))
+            } for each in value]
         else:
             included_data = {
                 'type': self.type_,
-                'id': get_value_or_raise(self.id_field, value)
+                'id': stringify(get_value_or_raise(self.id_field, value))
             }
         return included_data
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -46,7 +46,7 @@ class TestGenericRelationshipField:
         assert 'data' in result['author']
         assert result['author']['data']
 
-        assert result['author']['data']['id'] == post.author.id
+        assert result['author']['data']['id'] == str(post.author.id)
 
     def test_include_data_many(self, post):
         field = Relationship(
@@ -58,7 +58,7 @@ class TestGenericRelationshipField:
         assert 'data' in result['comments']
         assert result['comments']['data']
         ids = [each['id'] for each in result['comments']['data']]
-        assert ids == [each.id for each in post.comments]
+        assert ids == [str(each.id) for each in post.comments]
 
     def test_include_null_data_single(self, post_with_null_author):
         field = Relationship(


### PR DESCRIPTION
`"The values of the id and type members MUST be strings."`  [Document resource objects](http://jsonapi.org/format/#document-resource-objects)

Since all resources must have a `string` type `id` field and `type` field, it follows that all relationship values that represent the `type` and `id` fields of their respective resource should also be strings.
