### PR TITLE
Foreign key serialization support

### DIFF
--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -4,8 +4,10 @@ fields for serializing JSON API-formatted hyperlinks.
 """
 # Make core fields importable from marshmallow_jsonapi
 from marshmallow.fields import *  # noqa
+from marshmallow.utils import get_value
 
-from .utils import resolve_params, get_value_or_raise
+from .utils import resolve_params
+
 
 class BaseRelationship(Field):
     """Base relationship field. This is used by `marshmallow_jsonapi.Schema` to determine
@@ -86,15 +88,14 @@ class Relationship(BaseRelationship):
 
     def add_resource_linkage(self, value):
         if self.many:
-            included_data = [
-                {'type': self.type_,
-                    'id': get_value_or_raise(self.id_field, each)}
-                for each in value
-            ]
+            included_data = [{
+                'type': self.type_,
+                'id': get_value(self.id_field, each, each)
+            } for each in value]
         else:
             included_data = {
                 'type': self.type_,
-                'id': get_value_or_raise(self.id_field, value)
+                'id': get_value(self.id_field, value, value)
             }
         return included_data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ def make_post(with_comments=True, with_author=True):
         id=fake.random_int(),
         title=fake.catch_phrase(),
         author=author,
+        author_id=author.id if with_author else None,
         comments=comments)
 
 def make_comment():

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -55,7 +55,7 @@ class TestGenericRelationshipField:
             include_data=True, type_='people'
         )
         result = field.serialize('author_id', post)
-        assert result['author_id']['data']['id'] == post.author.id
+        assert result['author_id']['data']['id'] == post.author_id
 
     def test_include_data_many(self, post):
         field = Relationship(

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -48,6 +48,15 @@ class TestGenericRelationshipField:
 
         assert result['author']['data']['id'] == post.author.id
 
+    def test_include_data_single_foreign_key(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/author/',
+            related_url_kwargs={'post_id': '<id>'},
+            include_data=True, type_='people'
+        )
+        result = field.serialize('author_id', post)
+        assert result['author_id']['data']['id'] == post.author.id
+
     def test_include_data_many(self, post):
         field = Relationship(
             related_url='/posts/{post_id}/comments',


### PR DESCRIPTION
Allows the schema to serialize foreign key relationship values instead of depending on the results of a lazy-loaded (or not) query.
