### PR TITLE
Added dump_to serialization support

### DIFF
--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -100,23 +100,20 @@ class Relationship(BaseRelationship):
 
     def _serialize(self, value, attr, obj):
         dict_class = self.parent.dict_class if self.parent else dict
-        ret = dict_class()
-        if hasattr(self.root, 'inflect'):
-            attr = self.root.inflect(attr)
-        ret[attr] = dict_class()
 
+        ret = dict_class()
         self_url = self.get_self_url(obj)
         related_url = self.get_related_url(obj)
         if self_url or related_url:
-            ret[attr]['links'] = dict_class()
+            ret['links'] = dict_class()
             if self_url:
-                ret[attr]['links']['self'] = self_url
+                ret['links']['self'] = self_url
             if related_url:
-                ret[attr]['links']['related'] = related_url
+                ret['links']['related'] = related_url
 
         if self.include_data:
             if value is None:
-                ret[attr]['data'] = [] if self.many else None
+                ret['data'] = [] if self.many else None
             else:
-                ret[attr]['data'] = self.add_resource_linkage(value)
+                ret['data'] = self.add_resource_linkage(value)
         return ret

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -197,15 +197,21 @@ class Schema(ma.Schema):
         See: http://jsonapi.org/format/#document-resource-objects
         """
         ret = self.dict_class()
-        type_ = self.opts.type_
-        ret[TYPE] = type_
+        ret[TYPE] = self.opts.type_
+
+        # Get the schema attributes so we can confirm `dump-to` values exist
+        attributes = {}
+        for field in self.fields:
+            attributes[self.fields[field].dump_to or field] = field
+
         for field_name, value in iteritems(item):
-            if field_name == ID:
+            attribute = attributes[field_name]
+            if attribute == ID:
                 ret[ID] = value
-            elif isinstance(self.fields[field_name], BaseRelationship):
+            elif isinstance(self.fields[attribute], BaseRelationship):
                 if 'relationships' not in ret:
                     ret['relationships'] = self.dict_class()
-                ret['relationships'].update(value)
+                ret['relationships'][self.inflect(field_name)] = value
             else:
                 if 'attributes' not in ret:
                     ret['attributes'] = self.dict_class()

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -208,9 +208,10 @@ class Schema(ma.Schema):
         ret[TYPE] = self.opts.type_
 
         # Get the schema attributes so we can confirm `dump-to` values exist
-        attributes = {}
-        for field in self.fields:
-            attributes[self.fields[field].dump_to or field] = field
+        attributes = {
+            (self.fields[field].dump_to or field): field
+            for field in self.fields
+        }
 
         for field_name, value in iteritems(item):
             attribute = attributes[field_name]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import re
 from setuptools import setup, find_packages
 
 REQUIRES = [
-    'marshmallow>=2.0.0rc2'
+    'marshmallow>=2.3.0'
 ]
 
 def find_version(fname):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -13,7 +13,7 @@ class TestGenericRelationshipField:
         )
         result = field.serialize('comments', post)
         assert field.serialize('comments', post)
-        related = result['comments']['links']['related']
+        related = result['links']['related']
         assert related == 'http://example.com/posts/{id}/comments'.format(id=post.id)
 
     def test_serialize_self_link(self, post):
@@ -22,9 +22,8 @@ class TestGenericRelationshipField:
             self_url_kwargs={'id': '<id>'}
         )
         result = field.serialize('comments', post)
-        assert field.serialize('comments', post)
-        related = result['comments']['links']['self']
-        assert 'related' not in result['comments']['links']
+        related = result['links']['self']
+        assert 'related' not in result['links']
         assert related == 'http://example.com/posts/{id}/relationships/comments'.format(id=post.id)
 
     def test_include_data_requires_type(self, post):
@@ -43,10 +42,10 @@ class TestGenericRelationshipField:
             include_data=True, type_='people'
         )
         result = field.serialize('author', post)
-        assert 'data' in result['author']
-        assert result['author']['data']
+        assert 'data' in result
+        assert result['data']
 
-        assert result['author']['data']['id'] == post.author.id
+        assert result['data']['id'] == post.author.id
 
     def test_include_data_many(self, post):
         field = Relationship(
@@ -55,9 +54,8 @@ class TestGenericRelationshipField:
             many=True, include_data=True, type_='comments'
         )
         result = field.serialize('comments', post)
-        assert 'data' in result['comments']
-        assert result['comments']['data']
-        ids = [each['id'] for each in result['comments']['data']]
+        assert 'data' in result
+        ids = [each['id'] for each in result['data']]
         assert ids == [each.id for each in post.comments]
 
     def test_include_null_data_single(self, post_with_null_author):
@@ -67,8 +65,8 @@ class TestGenericRelationshipField:
             include_data=True, type_='people'
         )
         result = field.serialize('author', post_with_null_author)
-        assert result['author'] and result['author']['links']['related']
-        assert result['author']['data'] == None
+        assert result and result['links']['related']
+        assert result['data'] == None
 
     def test_include_null_data_many(self, post_with_null_comment):
         field = Relationship(
@@ -77,8 +75,8 @@ class TestGenericRelationshipField:
             many=True, include_data=True, type_='comments'
         )
         result = field.serialize('comments', post_with_null_comment)
-        assert result['comments'] and result['comments']['links']['related']
-        assert result['comments']['data'] == []
+        assert result and result['links']['related']
+        assert result['data'] == []
 
     def test_exclude_data(self, post_with_null_comment):
         field = Relationship(
@@ -87,8 +85,8 @@ class TestGenericRelationshipField:
             many=True, include_data=False, type_='comments'
         )
         result = field.serialize('comments', post_with_null_comment)
-        assert result['comments'] and result['comments']['links']['related']
-        assert 'data' not in result['comments']
+        assert result and result['links']['related']
+        assert 'data' not in result
 
     def test_is_dump_only_by_default(self):
         field = Relationship(

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -32,8 +32,9 @@ class TestRelationshipField:
             related_view_kwargs={'post_id': '<id>'},
         )
         result = field.serialize('comments', post)
-        assert 'comments' in result
-        related = result['comments']['links']['related']
+        assert 'links' in result
+        assert 'related' in result['links']
+        related = result['links']['related']
         assert related == url_for('posts_comments', post_id=post.id)
 
     def test_serialize_external(self, app, post):
@@ -42,7 +43,7 @@ class TestRelationshipField:
             related_view_kwargs={'post_id': '<id>', '_external': True},
         )
         result = field.serialize('comments', post)
-        related = result['comments']['links']['related']
+        related = result['links']['related']
         assert related == url_for('posts_comments', post_id=post.id, _external=True)
 
     def test_include_data_requires_type(self, app, post):
@@ -67,8 +68,9 @@ class TestRelationshipField:
             self_view_kwargs={'post_id': '<id>'},
         )
         result = field.serialize('comments', post)
-        assert 'comments' in result
-        related = result['comments']['links']['self']
+        assert 'links' in result
+        assert 'self' in result['links']
+        related = result['links']['self']
         assert related == url_for('posts_comments', post_id=post.id)
 
     def test_empty_relationship(self, app, post_with_null_author):
@@ -78,7 +80,7 @@ class TestRelationshipField:
         )
         result = field.serialize('author', post_with_null_author)
 
-        assert not result['author']
+        assert not result
 
     def test_non_existing_view(self, app, post):
         field = Relationship(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,6 +5,7 @@ from marshmallow import validate, ValidationError
 from marshmallow_jsonapi import Schema, fields
 from marshmallow_jsonapi.exceptions import IncorrectTypeError
 
+
 class AuthorSchema(Schema):
     id = fields.Int(dump_only=True)
     first_name = fields.Str(required=True)
@@ -21,6 +22,20 @@ class AuthorSchema(Schema):
 
     class Meta:
         type_ = 'people'
+
+
+class PostSchema(Schema):
+    id = fields.Int()
+    post_title = fields.Str(attribute='title')
+
+    post_comments = fields.Relationship(
+        'http://test.test/posts/{id}/comments/',
+        related_url_kwargs={'id': '<id>'},
+        attribute='comments', dump_to='post-comments'
+    )
+
+    class Meta:
+        type_ = 'posts'
 
 
 def test_type_is_required():
@@ -82,6 +97,12 @@ class TestResponseFormatting:
         data = AuthorSchema(many=True).dump(authors).data
         assert 'links' in data
         assert data['links']['self'] == '/authors/'
+
+    def test_dump_to(self, post):
+        data = PostSchema().dump(post).data
+        assert 'data' in data
+        assert 'relationships' in data['data']
+        assert 'post-comments' in data['data']['relationships']
 
 def get_error_by_field(errors, field):
     for err in errors['errors']:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -26,7 +26,7 @@ class AuthorSchema(Schema):
 
 class PostSchema(Schema):
     id = fields.Int()
-    post_title = fields.Str(attribute='title')
+    post_title = fields.Str(attribute='title', dump_to='title')
 
     post_comments = fields.Relationship(
         'http://test.test/posts/{id}/comments/',
@@ -101,6 +101,8 @@ class TestResponseFormatting:
     def test_dump_to(self, post):
         data = PostSchema().dump(post).data
         assert 'data' in data
+        assert 'attributes' in data['data']
+        assert 'title' in data['data']['attributes']
         assert 'relationships' in data['data']
         assert 'post-comments' in data['data']['relationships']
 


### PR DESCRIPTION
This pull request does the following:
1. At the schema level, we map the dump key to the schema attribute.  This aids in the validation process (which object the field will fall under `attributes` or `relationships`).
2. At the schema level, we manage relationships and attributes the same way.  The field is inflected and then assigned a value.
3. At the relationship level, the _serialize method returns the value as opposed to a dictionary of the inflected key and its value.  The management of the key defers to the schema as in the case of all other field types.
