### PR TITLE
Relationships must always include `data` key (deserialization)

### DIFF
--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -143,11 +143,11 @@ class Relationship(BaseRelationship):
     def _deserialize(self, value, attr, obj):
         if self.many:
             if not isinstance(value, list):
-                raise ValidationError('Relationship is list-like.')
+                raise ValidationError('Relationship is list-like')
             return [self.extract_value(item) for item in value]
 
         if isinstance(value, list):
-            raise ValidationError('Relationship is not list-like.')
+            raise ValidationError('Relationship is not list-like')
         return self.extract_value(value)
 
     def _serialize(self, value, attr, obj):

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -131,14 +131,7 @@ class Relationship(BaseRelationship):
         """
         if not isinstance(value, dict) or 'data' not in value:
             raise ValidationError('Must include a `data` key')
-        value = value['data']
-
-        self._validate_missing(value)
-        if getattr(self, 'allow_none', False) is True and value is None:
-            return None
-        output = self._deserialize(value, attr, data)
-        self._validate(output)
-        return output
+        return super(Relationship, self).deserialize(value['data'], attr, data)
 
     def _deserialize(self, value, attr, obj):
         if self.many:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -123,7 +123,7 @@ class TestGenericRelationshipField:
     def test_deserialize_null_data_value(self, post):
         field = Relationship(
             related_url='/posts/{post_id}/comments',
-            related_url_kwargs={'post_id': '<id>'},
+            related_url_kwargs={'post_id': '<id>'}, allow_none=True,
             many=False, include_data=False, type_='comments'
         )
         result = field.deserialize({'data': None})
@@ -133,7 +133,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
-            many=False, include_data=False, type_='comments'
+            many=True, include_data=False, type_='comments'
         )
         result = field.deserialize({'data': []})
         assert result == []

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -159,6 +159,20 @@ class TestGenericRelationshipField:
             field.deserialize({})
         assert excinfo.value.args[0] == 'Must include a `data` key'
 
+    def test_deserialize_many_non_list_relationship(self):
+        """Test deserializing many-to-one field with a non-list value."""
+        field = Relationship(many=True, include_data=True, type_='comments')
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize({'data': '1'})
+        assert excinfo.value.args[0] == 'Relationship is list-like'
+
+    def test_deserialize_non_many_list_relationship(self):
+        """Test deserializing one-to-one field with a list value."""
+        field = Relationship(many=False, include_data=True, type_='comments')
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize({'data': ['1']})
+        assert excinfo.value.args[0] == 'Relationship is not list-like'
+
     def test_include_null_data_single(self, post_with_null_author):
         field = Relationship(
             related_url='posts/{post_id}/author',

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -129,6 +129,16 @@ class TestGenericRelationshipField:
         result = field.deserialize({'data': None})
         assert result is None
 
+    def test_deserialize_null_value_disallow_none(self):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'}, allow_none=False,
+            many=False, include_data=False, type_='comments'
+        )
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize({'data': None})
+        assert excinfo.value.args[0] == 'Field may not be null.'
+
     def test_deserialize_empty_data_list(self, post):
         field = Relationship(
             related_url='/posts/{post_id}/comments',


### PR DESCRIPTION
The JSON API specification says that in order to nullify a relationship, you must specify an object with a key of data and a value of null.

To properly validate relationships with the `allow_none` kwarg specified, I've moved the data envelope validation up the stack to the `deserialize` method.  I've also added validation that ensures the value's data type matches the `many` kwarg's declaration.

http://jsonapi.org/format/#crud-updating-relationships
