### PR TITLE
Bulk request handling

### DIFF
--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -105,8 +105,6 @@ class Schema(ma.Schema):
             raise ma.ValidationError('`data` object must include `type` key.')
         if item['type'] != self.opts.type_:
             raise IncorrectTypeError(actual=item['type'], expected=self.opts.type_)
-        if 'attributes' not in item:
-            raise ma.ValidationError('`data` object must include `attributes` key.')
 
         payload = self.dict_class()
         for key, value in iteritems(item.get('attributes', {})):

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -107,6 +107,8 @@ class Schema(ma.Schema):
             raise IncorrectTypeError(actual=item['type'], expected=self.opts.type_)
 
         payload = self.dict_class()
+        if 'id' in item:
+            payload['id'] = item['id']
         for key, value in iteritems(item.get('attributes', {})):
             payload[key] = value
         for key, value in iteritems(item.get('relationships', {})):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7,7 +7,7 @@ from marshmallow_jsonapi.exceptions import IncorrectTypeError
 
 
 class AuthorSchema(Schema):
-    id = fields.Int(dump_only=True)
+    id = fields.Int()
     first_name = fields.Str(required=True)
     last_name = fields.Str(required=True)
     password = fields.Str(load_only=True, validate=validate.Length(6))
@@ -283,6 +283,16 @@ class TestInflection:
         assert not errs
         assert data['first_name'] == 'Steve'
         assert data['last_name'] == 'Loria'
+
+    def test_load_bulk_id_fields(self):
+        request = {'data': [{'id': 1, 'type': 'people'}]}
+
+        result, err = AuthorSchema(only=('id',), many=True).load(request)
+        assert err == {}
+        assert type(result) is list
+
+        response = result[0]
+        assert response['id'] == request['data'][0]['id']
 
     def test_relationship_keys_get_inflected(self, post):
         class PostSchema(Schema):


### PR DESCRIPTION
For bulk `DELETE` requests, an `id` and a `type` are the only required fields[1].

I've removed the validation around the required `attributes` key and I've added payload `id` marshaling.  `id` fields will need their `dump_only` kwargs set to `True` if the developer wants the old behavior.
1. http://jsonapi.org/extensions/bulk/
