### PR TITLE
compound documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ _sandbox
 # Virtual Environment
 env
 venv
+.python-version

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Contributors (chronological)
 - `@floqqi <https://github.com/floqqi>`_
 - Colton Allen `@cmanallen <https://github.com/cmanallen>`_
 - Dominik Steinberger `@ZeeD26 <https://github.com/ZeeD26>`_
+- Tim Mundt `@Tim-Erwin <https://github.com/Tim-Erwin>`_

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ marshmallow-jsonapi provides a simple way to produce JSON API-compliant data in 
             '/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
             # Include resource linkage
-            many=True, include_data=True,
+            many=True, include_resource_linkage=True,
             type_='comments'
         )
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ marshmallow-jsonapi provides a simple way to produce JSON API-compliant data in 
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
             # Include resource linkage
-            many=True, include_data=True,
+            many=True, include_resource_linkage=True,
             type_='comments'
         )
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -100,7 +100,7 @@ To serialize links, pass a URL format string and a dictionary of keyword argumen
 Resource linkages
 -----------------
 
-You can serialize `resource linkages <http://jsonapi.org/format/#document-resource-object-linkage>`_ by passing ``include_data=True`` .
+You can serialize `resource linkages <http://jsonapi.org/format/#document-resource-object-linkage>`_ by passing ``include_resource_linkage=True`` .
 
 .. code-block:: python
     :emphasize-lines: 8-10
@@ -113,7 +113,7 @@ You can serialize `resource linkages <http://jsonapi.org/format/#document-resour
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
             # Include resource linkage
-            many=True, include_data=True,
+            many=True, include_resource_linkage=True,
             type_='comments'
         )
         class Meta:
@@ -272,7 +272,7 @@ For example, the ``Relationship`` field in the ``marshmallow_jsonapi.flask`` mod
         comments = Relationship(
             related_view='article_comments',
             related_view_kwargs={'article_id': '<id>'},
-            many=True, include_data=True,
+            many=True, include_resource_linkage=True,
             type_='comments'
         )
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -140,6 +140,69 @@ You can serialize `resource linkages <http://jsonapi.org/format/#document-resour
     #     }
     # }
 
+
+Compound Documents
+------------------
+
+`Compound documents <http://jsonapi.org/format/#document-compound-documents>`_ allow to include related resources into the request with the primary resource. In order to include objects, you have to define a `Schema <marshmallow_json.schema.Schema>` for the respective relationship, which will be used to render those objects.
+
+.. code-block:: python
+    :emphasize-lines: 10-11
+
+    class ArticleSchema(Schema):
+        id = fields.Str(dump_only=True)
+        title = fields.Str()
+
+        comments = fields.Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=True, include_resource_linkage=True,
+            type_='comments',
+            # define a schema for rendering included data
+            schema='CommentSchema'
+        )
+        class Meta:
+            type_ = 'articles'
+            strict = True
+
+Just as with nested fields the ``schema`` can be a class or a string with a simple or fully qualified class name. Make sure to import the schema beforehand.
+
+Now you can include some data in a dump by specifying the includes.
+
+.. code-block:: python
+
+    ArticleSchema(include=('comments',)).dump(article).data
+    # {
+    #     "data": {
+    #         "id": 1,
+    #         "type": "articles"
+    #         "attributes": {"title": "Django is Omakase"},
+    #         "relationships": {
+    #             "comments": {
+    #                 "links": {
+    #                     "related": "/posts/1/comments/"
+    #                 }
+    #                 "data": [
+    #                     {"id": 5, "type": "comments"},
+    #                     {"id": 12, "type": "comments"}
+    #                 ],
+    #             }
+    #         },
+    #     }
+    #     "included": [
+    #         {
+    #             "data": {
+    #                 "attributes": {
+    #                     "body": "Marshmallow is sweet like sugar!"
+    #                 },
+    #                 "id": 17,
+    #                 "type": "comments"
+    #             }
+    #         }
+    #     ]
+    # }
+
+
 Errors
 ======
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -191,13 +191,12 @@ Now you can include some data in a dump by specifying the includes.
     #     }
     #     "included": [
     #         {
-    #             "data": {
-    #                 "attributes": {
-    #                     "body": "Marshmallow is sweet like sugar!"
-    #                 },
-    #                 "id": 17,
-    #                 "type": "comments"
-    #             }
+    #             "attributes": {
+    #                 "body": "Marshmallow is sweet like sugar!"
+    #             },
+    #             "id": 17,
+    #             "links": {"self": "/comments/17/"},
+    #             "type": "comments"
     #         }
     #     ]
     # }

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -171,7 +171,7 @@ Now you can include some data in a dump by specifying the includes.
 
 .. code-block:: python
 
-    ArticleSchema(include=('comments',)).dump(article).data
+    ArticleSchema(include_data=('comments',)).dump(article).data
     # {
     #     "data": {
     #         "id": 1,

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -193,15 +193,14 @@ class Relationship(BaseRelationship):
         if self.include_data and value is not None:
             if self.many:
                 for item in value:
-                    # items need to be dumped separately,
-                    # othwerwise we'd get a JSONAPI list
-                    result = self.schema.dump(item)
-                    if result.errors:
-                        raise ValidationError(result.errors)
-                    self.root.included_data.append(result.data['data'])
+                    self._serialize_included(item)
             else:
-                result = self.schema.dump(value)
-                if result.errors:
-                    raise ValidationError(result.errors)
-                self.root.included_data.append(result.data['data'])
+                self._serialize_included(value)
         return ret
+
+    def _serialize_included(self, value):
+        result = self.schema.dump(value)
+        if result.errors:
+            raise ValidationError(result.errors)
+        item = result.data['data']
+        self.root.included_data[(item['type'], item['id'])] = item

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -25,7 +25,7 @@ class BaseRelationship(Field):
     pass
 
 
-def stringify(value):
+def _stringify(value):
     if value is not None:
         return str(value)
     return value
@@ -118,12 +118,12 @@ class Relationship(BaseRelationship):
         if self.many:
             resource_object = [{
                 'type': self.type_,
-                'id': stringify(get_value(self.id_field, each, each))
+                'id': _stringify(get_value(self.id_field, each, each))
             } for each in value]
         else:
             resource_object = {
                 'type': self.type_,
-                'id': stringify(get_value(self.id_field, value, value))
+                'id': _stringify(get_value(self.id_field, value, value))
             }
         return resource_object
 

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -60,8 +60,6 @@ class Relationship(BaseRelationship):
         enclosed in `< >` will be interpreted as attributes to pull from the target object.
     :param bool include_resource_object: Whether to include a resource linkage
         (http://jsonapi.org/format/#document-resource-object-linkage) in the serialized result.
-    :param bool include_data: Whether to include the attributes of the related object as
-        included member. Only affects serialization.
     :param Schema schema: The schema to render the included data with when include_data is True.
     :param bool many: Whether the relationship represents a many-to-one or many-to-many
         relationship. Only affects serialization of the resource linkage.
@@ -75,7 +73,7 @@ class Relationship(BaseRelationship):
         self,
         related_url='', related_url_kwargs=None,
         self_url='', self_url_kwargs=None,
-        include_resource_object=False, include_data=False, schema=None,
+        include_resource_object=False, schema=None,
         many=False, type_=None, id_field=None, **kwargs
     ):
         self.related_url = related_url
@@ -84,13 +82,9 @@ class Relationship(BaseRelationship):
         self.self_url_kwargs = self_url_kwargs or {}
         if include_resource_object and not type_:
             raise ValueError('include_resource_object=True requires the type_ argument.')
-        if include_data and not type_:
-            raise ValueError('include_data=True requires the type_ argument.')
-        if include_data and not schema:
-            raise ValueError('include_data=True requires the schema argument.')
         self.many = many
-        self.include_resource_object = include_resource_object or include_data
-        self.include_data = include_data
+        self.include_resource_object = include_resource_object
+        self.include_data = False
         self.__schema = schema
         self.type_ = type_
         self.id_field = id_field or self.id_field

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -46,7 +46,7 @@ class Relationship(BaseRelationship):
         comments = Relationship(
             related_url='/posts/{post_id}/comments/',
             related_url_kwargs={'post_id': '<id>'},
-            many=True, include_data=True,
+            many=True, include_resource_linkage=True,
             type_='comments'
         )
 
@@ -58,9 +58,9 @@ class Relationship(BaseRelationship):
     :param str self_url: Format string for self relationship links.
     :param dict self_url_kwargs: Replacement fields for `self_url`. String arguments
         enclosed in `< >` will be interpreted as attributes to pull from the target object.
-    :param bool include_resource_object: Whether to include a resource linkage
+    :param bool include_resource_linkage: Whether to include a resource linkage
         (http://jsonapi.org/format/#document-resource-object-linkage) in the serialized result.
-    :param Schema schema: The schema to render the included data with when include_data is True.
+    :param Schema schema: The schema to render the included data with.
     :param bool many: Whether the relationship represents a many-to-one or many-to-many
         relationship. Only affects serialization of the resource linkage.
     :param str type_: The type of resource.
@@ -73,17 +73,17 @@ class Relationship(BaseRelationship):
         self,
         related_url='', related_url_kwargs=None,
         self_url='', self_url_kwargs=None,
-        include_resource_object=False, schema=None,
+        include_resource_linkage=False, schema=None,
         many=False, type_=None, id_field=None, **kwargs
     ):
         self.related_url = related_url
         self.related_url_kwargs = related_url_kwargs or {}
         self.self_url = self_url
         self.self_url_kwargs = self_url_kwargs or {}
-        if include_resource_object and not type_:
-            raise ValueError('include_resource_object=True requires the type_ argument.')
+        if include_resource_linkage and not type_:
+            raise ValueError('include_resource_linkage=True requires the type_ argument.')
         self.many = many
-        self.include_resource_object = include_resource_object
+        self.include_resource_linkage = include_resource_linkage
         self.include_data = False
         self.__schema = schema
         self.type_ = type_
@@ -176,7 +176,7 @@ class Relationship(BaseRelationship):
             if related_url:
                 ret['links']['related'] = related_url
 
-        if self.include_resource_object:
+        if self.include_resource_linkage:
             if value is None:
                 ret['data'] = [] if self.many else None
             else:

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -13,6 +13,9 @@ from marshmallow.utils import get_value, is_collection
 from .utils import resolve_params
 
 
+_RECURSIVE_NESTED = 'self'
+
+
 class BaseRelationship(Field):
     """Base relationship field.
 
@@ -98,8 +101,12 @@ class Relationship(BaseRelationship):
             self.__schema = self.__schema()
             return self.__schema
         if isinstance(self.__schema, basestring):
-            schema_class = class_registry.get_class(self.__schema)
-            self.__schema = schema_class()
+            if self.__schema == _RECURSIVE_NESTED:
+                parent_class = self.parent.__class__
+                self.__schema = parent_class(many=self.many)
+            else:
+                schema_class = class_registry.get_class(self.__schema)
+                self.__schema = schema_class()
             return self.__schema
 
     def get_related_url(self, obj):

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -176,7 +176,8 @@ class Relationship(BaseRelationship):
             if related_url:
                 ret['links']['related'] = related_url
 
-        if self.include_resource_linkage:
+        # resource linkage is required when including the data
+        if self.include_resource_linkage or self.include_data:
             if value is None:
                 ret['data'] = [] if self.many else None
             else:
@@ -190,10 +191,10 @@ class Relationship(BaseRelationship):
                     result = self.schema.dump(item)
                     if result.errors:
                         raise ValidationError(result.errors)
-                    self.root.included_data.append(result.data)
+                    self.root.included_data.append(result.data['data'])
             else:
                 result = self.schema.dump(value)
                 if result.errors:
                     raise ValidationError(result.errors)
-                self.root.included_data.append(result.data)
+                self.root.included_data.append(result.data['data'])
         return ret

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -96,18 +96,21 @@ class Relationship(BaseRelationship):
     @property
     def schema(self):
         if isinstance(self.__schema, SchemaABC):
-            return self.__schema
-        if isinstance(self.__schema, type) and issubclass(self.__schema, SchemaABC):
-            self.__schema = self.__schema()
-            return self.__schema
-        if isinstance(self.__schema, basestring):
+            pass
+        elif isinstance(self.__schema, type) and issubclass(self.__schema, SchemaABC):
+            self.__schema = self.__schema(many=self.many)
+        elif isinstance(self.__schema, basestring):
             if self.__schema == _RECURSIVE_NESTED:
                 parent_class = self.parent.__class__
-                self.__schema = parent_class(many=self.many)
+                self.__schema = parent_class(
+                    include_data=self.parent.include_data)
             else:
                 schema_class = class_registry.get_class(self.__schema)
                 self.__schema = schema_class()
-            return self.__schema
+        else:
+            raise ValueError(('A Schema is required to serialize a nested '
+                              'relationship with include_data'))
+        return self.__schema
 
     def get_related_url(self, obj):
         if self.related_url:

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -81,17 +81,17 @@ class Schema(ma.Schema):
         for field_name, field in self.fields.items():
             if field_name in self.include_data:
                 if not isinstance(field, BaseRelationship):
-                    raise ValueError('Can only include relationships. "%s" is a "%s"'
-                                     % (field_name, field.__class__.__name__))
+                    raise ValueError('Can only include relationships. "{}" is a "{}"'
+                                     .format(field_name, field.__class__.__name__))
                 if not hasattr(field, 'schema') or not field.schema:
-                    raise ValueError('A schema is required to serialize "%s"' % field_name)
+                    raise ValueError('A schema is required to serialize "{}"'.format(field_name))
                 field.include_data = True
-            else:
+            elif isinstance(field, BaseRelationship):
                 field.include_data = False
 
         for field_name in self.include_data:
             if field_name not in self.fields:
-                raise ValueError('Unknown field "%s"' % field_name)
+                raise ValueError('Unknown field "{}"'.format(field_name))
 
         if not self.opts.type_:
             raise ValueError('Must specify type_ class Meta option')
@@ -102,7 +102,7 @@ class Schema(ma.Schema):
         if self.opts.self_url_kwargs and not self.opts.self_url:
             raise ValueError('Must specify `self_url` Meta option when '
                              '`self_url_kwargs` is specified')
-        self.included_data = []
+        self.included_data = {}
 
     OPTIONS_CLASS = SchemaOpts
 
@@ -120,7 +120,7 @@ class Schema(ma.Schema):
     def render_included_data(self, data):
         if not self.included_data:
             return data
-        data['included'] = self.included_data
+        data['included'] = list(self.included_data.values())
         return data
 
     def unwrap_item(self, item):

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -75,9 +75,9 @@ class Schema(ma.Schema):
         """
         pass
 
-    def __init__(self, *args, include_data=(), **kwargs):
+    def __init__(self, *args, **kwargs):
+        self.include_data = kwargs.pop('include_data', ())
         super(Schema, self).__init__(*args, **kwargs)
-        self.include_data = include_data
         for field_name, field in self.fields.items():
             if field_name in self.include_data:
                 if not isinstance(field, BaseRelationship):

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -88,8 +88,7 @@ class Schema(ma.Schema):
         if self.opts.self_url_kwargs and not self.opts.self_url:
             raise ValueError('Must specify `self_url` Meta option when '
                              '`self_url_kwargs` is specified')
-        self.included_schemas = self.opts.included_schemas
-        self.included_data = {}
+        self.included_data = []
 
     OPTIONS_CLASS = SchemaOpts
 
@@ -107,17 +106,7 @@ class Schema(ma.Schema):
     def render_included_data(self, data):
         if not self.included_data:
             return data
-        included = []
-        for (type_, objId), value in self.included_data.items():
-            if type_ not in self.included_schemas:
-                raise ValueError('Must specify a schema in `included_schemas` for '
-                                 'type ' + type_)
-            schema = self.included_schemas[type_]
-            result = schema.dump(value)
-            if result.errors:
-                raise ma.ValidationError(result.errors)
-            included.append(result.data)
-        data['included'] = included
+        data['included'] = self.included_data
         return data
 
     def unwrap_item(self, item):

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -27,7 +27,6 @@ class SchemaOpts(ma.SchemaOpts):
         self.self_url = getattr(meta, 'self_url', None)
         self.self_url_kwargs = getattr(meta, 'self_url_kwargs', None)
         self.self_url_many = getattr(meta, 'self_url_many', None)
-        self.included_schemas = getattr(meta, 'included_schemas', {})
 
 class Schema(ma.Schema):
     """Schema class that formats data according to JSON API 1.0.
@@ -53,7 +52,7 @@ class Schema(ma.Schema):
                 '/posts/{post_id}/comments',
                 url_kwargs={'post_id': '<id>'},
                 # Include resource linkage
-                many=True, include_data=True,
+                many=True, include_resource_linkage=True,
                 type_='comments'
             )
 

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -83,8 +83,6 @@ class Schema(ma.Schema):
                 if not isinstance(field, BaseRelationship):
                     raise ValueError('Can only include relationships. "{}" is a "{}"'
                                      .format(field_name, field.__class__.__name__))
-                if not hasattr(field, 'schema') or not field.schema:
-                    raise ValueError('A schema is required to serialize "{}"'.format(field_name))
                 field.include_data = True
             elif isinstance(field, BaseRelationship):
                 field.include_data = False

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -27,40 +27,40 @@ class TestGenericRelationshipField:
         assert 'related' not in result['links']
         assert related == 'http://example.com/posts/{id}/relationships/comments'.format(id=post.id)
 
-    def test_include_data_requires_type(self, post):
+    def test_include_resource_linkage_requires_type(self, post):
         with pytest.raises(ValueError) as excinfo:
             Relationship(
                 related_url='/posts/{post_id}',
                 related_url_kwargs={'post_id': '<id>'},
-                include_data=True
+                include_resource_linkage=True
             )
-        assert excinfo.value.args[0] == 'include_data=True requires the type_ argument.'
+        assert excinfo.value.args[0] == 'include_resource_linkage=True requires the type_ argument.'
 
-    def test_include_data_single(self, post):
+    def test_include_resource_linkage_single(self, post):
         field = Relationship(
             related_url='/posts/{post_id}/author/',
             related_url_kwargs={'post_id': '<id>'},
-            include_data=True, type_='people'
+            include_resource_linkage=True, type_='people'
         )
         result = field.serialize('author', post)
         assert 'data' in result
         assert result['data']
         assert result['data']['id'] == str(post.author.id)
 
-    def test_include_data_single_foreign_key(self, post):
+    def test_include_resource_linkage_single_foreign_key(self, post):
         field = Relationship(
             related_url='/posts/{post_id}/author/',
             related_url_kwargs={'post_id': '<id>'},
-            include_data=True, type_='people'
+            include_resource_linkage=True, type_='people'
         )
         result = field.serialize('author_id', post)
         assert result['data']['id'] == str(post.author_id)
 
-    def test_include_data_many(self, post):
+    def test_include_resource_linkage_many(self, post):
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
-            many=True, include_data=True, type_='comments'
+            many=True, include_resource_linkage=True, type_='comments'
         )
         result = field.serialize('comments', post)
         assert 'data' in result
@@ -71,7 +71,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
-            many=False, include_data=True, type_='comments'
+            many=False, include_resource_linkage=True, type_='comments'
         )
         value = {'data': {'type': 'comments', 'id': '1'}}
         result = field.deserialize(value)
@@ -81,7 +81,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
-            many=True, include_data=True, type_='comments'
+            many=True, include_resource_linkage=True, type_='comments'
         )
         value = {'data': [{'type': 'comments', 'id': '1'}]}
         result = field.deserialize(value)
@@ -91,7 +91,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
-            many=False, include_data=True, type_='comments'
+            many=False, include_resource_linkage=True, type_='comments'
         )
         with pytest.raises(ValidationError) as excinfo:
             value = {'data': {'type': 'comments'}}
@@ -102,7 +102,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
-            many=False, include_data=True, type_='comments'
+            many=False, include_resource_linkage=True, type_='comments'
         )
         with pytest.raises(ValidationError) as excinfo:
             value = {'data': {'id': '1'}}
@@ -113,7 +113,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
-            many=False, include_data=True, type_='comments'
+            many=False, include_resource_linkage=True, type_='comments'
         )
         with pytest.raises(ValidationError) as excinfo:
             value = {'data': {'type': 'posts', 'id': '1'}}
@@ -124,7 +124,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'}, allow_none=True,
-            many=False, include_data=False, type_='comments'
+            many=False, include_resource_linkage=False, type_='comments'
         )
         result = field.deserialize({'data': None})
         assert result is None
@@ -133,7 +133,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'}, allow_none=False,
-            many=False, include_data=False, type_='comments'
+            many=False, include_resource_linkage=False, type_='comments'
         )
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize({'data': None})
@@ -143,7 +143,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
-            many=True, include_data=False, type_='comments'
+            many=True, include_resource_linkage=False, type_='comments'
         )
         result = field.deserialize({'data': []})
         assert result == []
@@ -152,7 +152,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
-            many=False, include_data=False, type_='comments'
+            many=False, include_resource_linkage=False, type_='comments'
         )
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize({'data': {}})
@@ -163,20 +163,20 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
-            many=False, include_data=False, type_='comments'
+            many=False, include_resource_linkage=False, type_='comments'
         )
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize({})
         assert excinfo.value.args[0] == 'Must include a `data` key'
 
     def test_deserialize_many_non_list_relationship(self):
-        field = Relationship(many=True, include_data=True, type_='comments')
+        field = Relationship(many=True, include_resource_linkage=True, type_='comments')
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize({'data': '1'})
         assert excinfo.value.args[0] == 'Relationship is list-like'
 
     def test_deserialize_non_many_list_relationship(self):
-        field = Relationship(many=False, include_data=True, type_='comments')
+        field = Relationship(many=False, include_resource_linkage=True, type_='comments')
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize({'data': ['1']})
         assert excinfo.value.args[0] == 'Relationship is not list-like'
@@ -185,7 +185,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='posts/{post_id}/author',
             related_url_kwargs={'post_id': '<id>'},
-            include_data=True, type_='people'
+            include_resource_linkage=True, type_='people'
         )
         result = field.serialize('author', post_with_null_author)
         assert result and result['links']['related']
@@ -195,7 +195,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
-            many=True, include_data=True, type_='comments'
+            many=True, include_resource_linkage=True, type_='comments'
         )
         result = field.serialize('comments', post_with_null_comment)
         assert result and result['links']['related']
@@ -205,7 +205,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
-            many=True, include_data=False, type_='comments'
+            many=True, include_resource_linkage=False, type_='comments'
         )
         result = field.serialize('comments', post_with_null_comment)
         assert result and result['links']['related']

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -46,14 +46,14 @@ class TestRelationshipField:
         related = result['links']['related']
         assert related == url_for('posts_comments', post_id=post.id, _external=True)
 
-    def test_include_data_requires_type(self, app, post):
+    def test_include_resource_linkage_requires_type(self, app, post):
         with pytest.raises(ValueError) as excinfo:
             Relationship(
                 related_view='posts_comments',
                 related_view_kwargs={'post_id': '<id>'},
-                include_data=True
+                include_resource_linkage=True
             )
-        assert excinfo.value.args[0] == 'include_data=True requires the type_ argument.'
+        assert excinfo.value.args[0] == 'include_resource_linkage=True requires the type_ argument.'
 
     def test_serialize_self_link(self, app, post):
         field = Relationship(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -129,18 +129,16 @@ class TestCompoundDocuments:
         assert 'included' in data
         assert len(data['included']) == 2
         first_comment = data['included'][0]
-        assert 'data' in first_comment
-        assert 'attributes' in first_comment['data']
-        assert 'body' in first_comment['data']['attributes']
+        assert 'attributes' in first_comment
+        assert 'body' in first_comment['attributes']
 
     def test_include_data_with_single(self, post):
         data = PostSchema(include_data=('author',)).dump(post).data
         assert 'included' in data
         assert len(data['included']) == 1
         author = data['included'][0]
-        assert 'data' in author
-        assert 'attributes' in author['data']
-        assert 'first_name' in author['data']['attributes']
+        assert 'attributes' in author
+        assert 'first_name' in author['attributes']
 
     def test_include_data_with_all_relations(self, post):
         data = PostSchema(include_data=('author', 'post_comments')).dump(post).data

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -149,6 +149,25 @@ class TestCompoundDocuments:
         data = PostSchema(include_data=()).dump(post).data
         assert 'included' not in data
 
+    def test_include_self_referential_relationship(self):
+        class RefSchema(Schema):
+            id = fields.Int()
+            data = fields.Str()
+            parent = fields.Relationship(schema='self', many=False)
+            class Meta:
+                type_ = 'refs'
+
+        obj = {
+            'id': 1, 'data': 'data1',
+            'parent': {
+                'id': 2,
+                'data': 'data2'
+            }
+        }
+        data = RefSchema(include_data=('parent',)).dump(obj).data
+        assert 'included' in data
+        assert data['included'][0]['attributes']['data'] == 'data2'
+
 
 def get_error_by_field(errors, field):
     for err in errors['errors']:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -200,6 +200,49 @@ class TestCompoundDocuments:
         for child in data['included']:
             assert child['attributes']['data'] == 'data%s' % child['id']
 
+    def test_include_self_referential_relationship_many_deep(self):
+        class RefSchema(Schema):
+            id = fields.Str()
+            data = fields.Str()
+            children = fields.Relationship(schema='self', type_='refs',
+                                           many=True)
+
+            class Meta:
+                type_ = 'refs'
+
+        obj = {
+            'id': '1',
+            'data': 'data1',
+            'children': [
+                {
+                    'id': '2',
+                    'data': 'data2',
+                    'children': [],
+                },
+                {
+                    'id': '3',
+                    'data': 'data3',
+                    'children': [
+                        {
+                            'id': '4',
+                            'data': 'data4',
+                            'children': []
+                        },
+                        {
+                            'id': '5',
+                            'data': 'data5',
+                            'children': []
+                        }
+                    ]
+                }
+            ]
+        }
+        data = RefSchema(include_data=('children', )).dump(obj).data
+        assert 'included' in data
+        assert len(data['included']) == 4
+        for child in data['included']:
+            assert child['attributes']['data'] == 'data%s' % child['id']
+
 
 def get_error_by_field(errors, field):
     for err in errors['errors']:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -367,9 +367,9 @@ class ArticleSchema(Schema):
     id = fields.Integer()
     body = fields.String()
     author = fields.Relationship(
-        dump_only=False, include_data=True, many=False, type_='people')
+        dump_only=False, include_resource_linkage=True, many=False, type_='people')
     comments = fields.Relationship(
-        dump_only=False, include_data=True, many=True, type_='comments')
+        dump_only=False, include_resource_linkage=True, many=True, type_='comments')
 
     class Meta:
         type_ = 'articles'


### PR DESCRIPTION
This is prove of concept for an implementation of compound documents.
- I find the current `include_data` argument misleading and changed it to `include_resource_object`.
- With the `include_data` argument you can now include that data in the includes of the document.
- In order to do that you need to specify `included_schemas` in `Meta` like so:

```
class Foo(Schema):
    class Meta:
        type_ = 'foos'
        self_url = '/foos/{foo_id}/'
        self_url_kwargs = {'foo_id': '<id>'}
        included_schemas = {'bars': BarSchema()}
    bar = fields.Relationship(
        related_url='/bars/{bar_id}/',
        related_url_kwargs={'bar_id': '<bar_id>'},
        include_data=True,
        type_='bars')
```

When I then dump a foo with `include_data=True`, the included bar will be put into the included list of the document.

What's still problematic about my approach is, that the serialization of bar happens in a post_dump hook. Hence, the errors are not handled like other errors.

Any thoughts on this? Suggestions?
