### PR TITLE
Map relationship errors to deepest depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+.cache
 nosetests.xml
 
 # Translations
@@ -44,3 +45,7 @@ README.html
 
 _sandbox
 .konchrc
+
+# Virtual Environment
+env
+venv

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -182,7 +182,9 @@ class Schema(ma.Schema):
 
         See: http://jsonapi.org/format/#error-objects
         """
-        if isinstance(self.declared_fields.get(field_name), BaseRelationship):
+        relationship = isinstance(
+            self.declared_fields.get(field_name), BaseRelationship)
+        if relationship:
             container = 'relationships'
         else:
             container = 'attributes'
@@ -192,6 +194,10 @@ class Schema(ma.Schema):
             pointer = '/data/{}/{}/{}'.format(index, container, inflected_name)
         else:
             pointer = '/data/{}/{}'.format(container, inflected_name)
+
+        if relationship:
+            pointer = '{}/data'.format(pointer)
+
         return {
             'detail': message,
             'source': {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -382,9 +382,9 @@ class TestRelationshipLoading(object):
         """Walk through the dictionary and determine if a specific
         relationship pointer exists
         """
-        pointer = '/data/relationships/{}'.format(pointer)
+        pointer = '/data/relationships/{}/data'.format(pointer)
         for error in errors:
-            if pointer in error['source']['pointer']:
+            if pointer == error['source']['pointer']:
                 return True
         return False
 


### PR DESCRIPTION
Map relationship errors to the most specific path (`data` key).  The list of relationship errors will always refer to the `data` key itself, the `type` key, or the `id` key.  By mapping the error to the `data` key we are in line with the IETF RFC.
