### PR TITLE
Add fields.Meta to serialize the meta object on a resource object

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,3 +17,4 @@ Contributors (chronological)
 - Dominik Steinberger `@ZeeD26 <https://github.com/ZeeD26>`_
 - Tim Mundt `@Tim-Erwin <https://github.com/Tim-Erwin>`_
 - Brandon Wood `@woodb <https://github.com/woodb>`_
+- Frazer McLean `@RazerM <https://github.com/RazerM>`_

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ Flask
 # Testing
 pytest>=2.7.3
 tox>=1.5.0
-fake-factory
+faker
 
 # Packaging
 wheel

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -204,6 +204,38 @@ Now you can include some data in a dump by specifying the includes.
     # }
 
 
+Meta Objects
+============
+
+The :class:`marshmallow_jsonapi.fields.Meta` field is used to serialize the
+meta object within a `resource object <http://jsonapi.org/format/#document-resource-objects>`_.
+
+.. code-block:: python
+
+    from marshmallow_jsonapi import Schema, fields
+
+    class AuthorSchema(Schema):
+        id = fields.Str(dump_only=True)
+        name = fields.Str()
+        metadata = fields.Meta()
+
+        class Meta:
+            type_ = 'people'
+            strict = True
+
+    author = {'name': 'Alice', 'metadata': {'page': {'offset': 10}}}
+    AuthorSchema().dump(author).data
+    # {
+    #     "data": {
+    #         "id": 1,
+    #         "type": "people"
+    #         "attributes": {"name": "Alice"},
+    #         "meta": {"page": {"offset": 10}}
+    #     }
+    # }
+
+
+
 Errors
 ======
 

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -4,7 +4,7 @@ import marshmallow as ma
 from marshmallow.exceptions import ValidationError
 from marshmallow.compat import iteritems, PY2
 
-from .fields import BaseRelationship
+from .fields import BaseRelationship, Meta, _META_LOAD_FROM
 from .exceptions import IncorrectTypeError
 from .utils import resolve_params
 
@@ -138,6 +138,8 @@ class Schema(ma.Schema):
         payload = self.dict_class()
         if 'id' in item:
             payload['id'] = item['id']
+        if 'meta' in item:
+            payload[_META_LOAD_FROM] = item['meta']
         for key, value in iteritems(item.get('attributes', {})):
             payload[key] = value
         for key, value in iteritems(item.get('relationships', {})):
@@ -258,6 +260,10 @@ class Schema(ma.Schema):
             attribute = attributes[field_name]
             if attribute == ID:
                 ret[ID] = value
+            elif isinstance(self.fields[attribute], Meta):
+                if 'meta' not in ret:
+                    ret['meta'] = self.dict_class()
+                ret['meta'].update(value)
             elif isinstance(self.fields[attribute], BaseRelationship):
                 if 'relationships' not in ret:
                     ret['relationships'] = self.dict_class()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,7 +2,7 @@
 import pytest
 
 from marshmallow import ValidationError
-from marshmallow_jsonapi.fields import Relationship
+from marshmallow_jsonapi.fields import Meta, Relationship
 
 
 class TestGenericRelationshipField:
@@ -210,3 +210,30 @@ class TestGenericRelationshipField:
         result = field.serialize('comments', post_with_null_comment)
         assert result and result['links']['related']
         assert 'data' not in result
+
+
+class TestMetaField:
+
+    def test_serialize(self):
+        field = Meta()
+        result = field.serialize('meta', {'meta': {'page': {'offset': 1}}})
+        assert result == {'page': {'offset': 1}}
+
+    def test_serialize_incorrect_type(self):
+        field = Meta()
+        with pytest.raises(ValidationError) as excinfo:
+            field.serialize('meta', {'meta': 1})
+        assert excinfo.value.args[0] == 'Not a valid mapping type.'
+
+    def test_deserialize(self):
+        field = Meta()
+        value = {'page': {'offset': 1}}
+        result = field.deserialize(value)
+        assert result == value
+
+    def test_deserialize_incorrect_type(self):
+        field = Meta()
+        value = 1
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize(value)
+        assert excinfo.value.args[0] == 'Not a valid mapping type.'

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -528,6 +528,61 @@ class ArticleSchema(Schema):
         type_ = 'articles'
 
 
+class PolygonSchema(Schema):
+    id = fields.Integer(as_string=True)
+    sides = fields.Integer()
+    regular = fields.Boolean()
+    # This is an attribute that uses the 'meta' key: /data/attributes/meta
+    meta = fields.String()
+    # This is the resource object's meta object: /data/meta
+    resource_meta = fields.Meta()
+
+    class Meta:
+        type_ = 'shapes'
+
+
+class TestMeta(object):
+
+    serialized_shape = {
+        'data': {
+            'id': '1',
+            'type': 'shapes',
+            'attributes': {
+                'sides': 3,
+                'regular': False,
+                'meta': 'This is an ill-advised (albeit valid) attribute name.',
+            },
+            'meta': {
+                'some': 'metadata',
+            },
+        },
+        'links': {'self': None},
+    }
+
+    shape = {
+        'id': 1,
+        'sides': 3,
+        'regular': False,
+        'meta': 'This is an ill-advised (albeit valid) attribute name.',
+        'resource_meta': {'some': 'metadata'},
+    }
+
+    def test_deserialize_meta(self):
+        data = PolygonSchema().load(self.serialized_shape).data
+        assert data
+        assert data['id'] == 1
+        assert data['sides'] == 3
+        assert data['regular'] == False
+        assert data['meta'] == \
+               'This is an ill-advised (albeit valid) attribute name.'
+        assert data['resource_meta'] == {'some': 'metadata'}
+
+    def test_serialize_meta(self):
+        data = PolygonSchema().dump(self.shape).data
+        assert data == self.serialized_shape
+
+
+
 class TestRelationshipLoading(object):
 
     article = {


### PR DESCRIPTION
Implementation of #28. Based my approach on #29, but is more similar to `fields.Dict`.

I had to workaround the fact that `meta` is also a valid attribute name, so `unwrap_item` uses a member name that is disallowed by JSON API (starts with an underscore). This allows unwrapping `/data/meta` to a field named (e.g.) `resource_meta` while allowing `/data/attributes/meta` to be unwrapped to a field named `meta`. See the `TestMeta` class for what this looks like in practice.