### PR TITLE
Fix cd directory for marshmallow-jsonapi folder

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -26,7 +26,7 @@ Setting Up for Local Development
 1. Fork marshmallow-jsonapi_ on Github. ::
 
     $ git clone https://github.com/marshmallow-code/marshmallow-jsonapi.git
-    $ cd marshmallow
+    $ cd marshmallow-jsonapi
 
 2. Install development requirements. It is highly recommended that you use a virtualenv. ::
 


### PR DESCRIPTION
Setting up for fixing #58 and I noticed a couple small issues in the Contributing documentation. This fixes the first one.

However I'm not really sure what to do about the command for branching to fix a bug. The marshmallow-jsonapi repo doesn't have a line-1.2 branch that I can see. I'm branching from dev for these fixes. If there is a correct base branch for bugfixes I'd love to know and add it to this pull.