### PR TITLE
Pull Request for #58, Fix dump None

### DIFF
--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -247,6 +247,12 @@ class Schema(ma.Schema):
 
         See: http://jsonapi.org/format/#document-resource-objects
         """
+        # http://jsonapi.org/format/#document-top-level
+        # Primary data MUST be either... a single resource object, a single resource
+        # identifier object, or null, for requests that target single resources
+        if not item:
+            return None
+
         ret = self.dict_class()
         ret[TYPE] = self.opts.type_
 
@@ -313,9 +319,11 @@ class Schema(ma.Schema):
     def wrap_response(self, data, many):
         """Wrap data and links according to the JSON API """
         ret = {'data': data}
-        top_level_links = self.get_top_level_links(data, many)
-        if top_level_links:
-            ret['links'] = top_level_links
+        print('WRAP_RESPONSE', data)
+        if data:
+            top_level_links = self.get_top_level_links(data, many)
+            if top_level_links:
+                ret['links'] = top_level_links
         return ret
 
     def generate_url(self, link, **kwargs):

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -319,8 +319,9 @@ class Schema(ma.Schema):
     def wrap_response(self, data, many):
         """Wrap data and links according to the JSON API """
         ret = {'data': data}
-        print('WRAP_RESPONSE', data)
-        if data:
+        # self_url_many is still valid when there isn't any data, but self_url
+        # may only be included if there is data in the ret
+        if many or data:
             top_level_links = self.get_top_level_links(data, many)
             if top_level_links:
                 ret['links'] = top_level_links

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -323,7 +323,7 @@ class Schema(ma.Schema):
         # may only be included if there is data in the ret
         if many or data:
             top_level_links = self.get_top_level_links(data, many)
-            if top_level_links:
+            if top_level_links['self']:
                 ret['links'] = top_level_links
         return ret
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,10 @@ def authors():
     return [make_author() for _ in range(3)]
 
 @pytest.fixture()
+def comments():
+    return [make_comment() for _ in range(3)]
+
+@pytest.fixture()
 def post():
     return make_post()
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -133,11 +133,13 @@ class TestResponseFormatting:
 
     def test_dump_empty_list(self):
         data = AuthorSchema(many=True).dump([]).data
+        print('TEST_DUMP_EMPTY_LIST', data)
 
         assert 'data' in data
         assert type(data['data']) is list
         assert len(data['data']) == 0
-        assert 'links' not in data
+        assert 'links' in data
+        assert data['links']['self'] == '/authors/'
 
 
 class TestCompoundDocuments:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -124,6 +124,21 @@ class TestResponseFormatting:
         assert 'relationships' in data['data']
         assert 'post-comments' in data['data']['relationships']
 
+    def test_dump_none(self):
+        data = AuthorSchema().dump(None).data
+
+        assert 'data' in data
+        assert data['data'] is None
+        assert 'links' not in data
+
+    def test_dump_empty_list(self):
+        data = AuthorSchema(many=True).dump([]).data
+
+        assert 'data' in data
+        assert type(data['data']) is list
+        assert len(data['data']) == 0
+        assert 'links' not in data
+
 
 class TestCompoundDocuments:
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -133,7 +133,6 @@ class TestResponseFormatting:
 
     def test_dump_empty_list(self):
         data = AuthorSchema(many=True).dump([]).data
-        print('TEST_DUMP_EMPTY_LIST', data)
 
         assert 'data' in data
         assert type(data['data']) is list
@@ -532,6 +531,18 @@ class TestAutoSelfUrls:
         assert 'links' in data['data'][0]
         assert data['data'][0]['links']['self'] == '/authors/{}'.format(authors[0].id)
 
+    def test_without_self_link(self, comments):
+        data = CommentSchema(many=True).dump(comments).data
+
+        assert 'data' in data
+        assert type(data['data']) is list
+
+        first = data['data'][0]
+        assert first['id'] == comments[0].id
+        assert first['type'] == 'comments'
+
+        assert 'links' not in data
+
 
 class ArticleSchema(Schema):
     id = fields.Integer()
@@ -573,7 +584,6 @@ class TestMeta(object):
                 'some': 'metadata',
             },
         },
-        'links': {'self': None},
     }
 
     shape = {


### PR DESCRIPTION
These are fixes for the issues raised in #58.

When dump is called with None return a jsonapi data object that is None, without links objects.

When dump is called with an empty list return a jsonapi data object that is an empty list, without links objects.

When the Schema doesn't include self_url or self_url_many don't automatically include a None links object that breaks the jsonapi spec.