### PR TITLE
Support deep-nesting of include_data

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -169,7 +169,7 @@ Compound documents
 
 Just as with nested fields the ``schema`` can be a class or a string with a simple or fully qualified class name. Make sure to import the schema beforehand.
 
-Now you can include some data in a dump by specifying the includes.
+Now you can include some data in a dump by specifying the includes (also supports nested relations via the dot syntax).
 
 .. code-block:: python
 

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -96,22 +96,24 @@ class Schema(ma.Schema):
     OPTIONS_CLASS = SchemaOpts
 
     def check_relations(self, relations):
+        """Recursive function which checks if a relation is valid."""
         for rel in relations:
-            if rel:
-                rel = rel.split('.', 1)
-                local_field = rel[0]
+            if not rel:
+                continue
+            fields = rel.split('.', 1)
 
-                if local_field not in self.fields:
-                    raise ValueError('Unknown field "{}"'.format(local_field))
+            local_field = fields[0]
+            if local_field not in self.fields:
+                raise ValueError('Unknown field "{}"'.format(local_field))
 
-                field = self.fields[local_field]
-                if not isinstance(field, BaseRelationship):
-                    raise ValueError('Can only include relationships. "{}" is a "{}"'
-                                     .format(field.name, field.__class__.__name__))
+            field = self.fields[local_field]
+            if not isinstance(field, BaseRelationship):
+                raise ValueError('Can only include relationships. "{}" is a "{}"'
+                                 .format(field.name, field.__class__.__name__))
 
-                field.include_data = True
-                if len(rel) > 1:
-                    field.schema.check_relations(rel[1:])
+            field.include_data = True
+            if len(fields) > 1:
+                field.schema.check_relations(fields[1:])
 
     @ma.post_dump(pass_many=True)
     def format_json_api_response(self, data, many):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,9 @@ def make_post(with_comments=True, with_author=True):
         author_id=author.id if with_author else None,
         comments=comments)
 
-def make_comment():
-    return Comment(id=fake.random_int(), body=fake.bs())
+def make_comment(with_author=True):
+    author = make_author() if with_author else None
+    return Comment(id=fake.random_int(), body=fake.bs(), author=author)
 
 @pytest.fixture()
 def author():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -151,7 +151,7 @@ class TestCompoundDocuments:
         data = PostSchema(include_data=('post_comments', 'post_comments.author')).dump(post).data
         assert 'included' in data
         assert len(data['included']) == 4
-        first_comment = data['included'][0]
+        first_comment = [i for i in data['included'] if i['type'] == 'comments'][0]
         assert 'attributes' in first_comment
         assert 'body' in first_comment['attributes']
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -167,9 +167,11 @@ class TestCompoundDocuments:
         data = PostSchema(include_data=('author', 'post_comments', 'post_comments.author')).dump(post).data
         assert 'included' in data
         assert len(data['included']) == 5
-        for included in data['included']:
+        for i, included in enumerate(data['included']):
             assert included['id']
             assert included['type'] in ('people', 'comments')
+            if 'relationships' in included:
+                assert included['relationships']['author']['data']['id'] == str(data['included'][i + 1]['id'])
 
     def test_include_no_data(self, post):
         data = PostSchema(include_data=()).dump(post).data

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -50,6 +50,12 @@ class CommentSchema(Schema):
     id = fields.Int()
     body = fields.Str(required=True)
 
+    author = fields.Relationship(
+        'http://test.test/comments/{id}/author/',
+        related_url_kwargs={'id': '<id>'},
+        schema=AuthorSchema, many=False
+    )
+
     class Meta:
         type_ = 'comments'
 
@@ -142,9 +148,9 @@ class TestResponseFormatting:
 class TestCompoundDocuments:
 
     def test_include_data_with_many(self, post):
-        data = PostSchema(include_data=('post_comments',)).dump(post).data
+        data = PostSchema(include_data=('post_comments', 'post_comments.author')).dump(post).data
         assert 'included' in data
-        assert len(data['included']) == 2
+        assert len(data['included']) == 4
         first_comment = data['included'][0]
         assert 'attributes' in first_comment
         assert 'body' in first_comment['attributes']
@@ -158,9 +164,9 @@ class TestCompoundDocuments:
         assert 'first_name' in author['attributes']
 
     def test_include_data_with_all_relations(self, post):
-        data = PostSchema(include_data=('author', 'post_comments')).dump(post).data
+        data = PostSchema(include_data=('author', 'post_comments', 'post_comments.author')).dump(post).data
         assert 'included' in data
-        assert len(data['included']) == 3
+        assert len(data['included']) == 5
         for included in data['included']:
             assert included['id']
             assert included['type'] in ('people', 'comments')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -167,11 +167,13 @@ class TestCompoundDocuments:
         data = PostSchema(include_data=('author', 'post_comments', 'post_comments.author')).dump(post).data
         assert 'included' in data
         assert len(data['included']) == 5
-        for i, included in enumerate(data['included']):
+        for included in data['included']:
             assert included['id']
             assert included['type'] in ('people', 'comments')
-            if 'relationships' in included:
-                assert included['relationships']['author']['data']['id'] == str(data['included'][i + 1]['id'])
+        expected_comments_author_ids = set([comment.author.id for comment in post.comments])
+        included_comments_author_ids = set([i['id'] for i in data['included'] if i['type'] == 'people'
+                                                                              and i['id'] != post.author.id])
+        assert included_comments_author_ids == expected_comments_author_ids
 
     def test_include_no_data(self, post):
         data = PostSchema(include_data=()).dump(post).data


### PR DESCRIPTION
This change allows including deep-nested objects with include_data. To specify a remote field just separate the field names with a dot like "local_field.remote_field.another_remote_field".

This excludes unit tests for now, would write tests if I got feedback to that code.