### PR TITLE
Resource identifier objects, override top level links.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+branch=True
+source=
+    marshmallow_jsonapi
+    tests

--- a/marshmallow_jsonapi/flask.py
+++ b/marshmallow_jsonapi/flask.py
@@ -60,6 +60,42 @@ class Schema(DefaultSchema):
         """
         pass
 
+    def __init__(self, *args, **kwargs):
+        if kwargs.get('self_url', None):
+            raise TypeError('Use `self_view` instead of `self_url` '
+                            'using the Flask extension.')
+        if kwargs.get('self_url_kwargs', None):
+            raise TypeError('Use `self_view_kwargs` instead of '
+                            '`self_url_kwargs` when using the Flask extension.')
+        if kwargs.get('related_url', None):
+            raise TypeError('Use `related_view` instead of `related_url` '
+                             'using the Flask extension.')
+        if kwargs.get('related_url_kwargs', None):
+            raise TypeError('Use `related_view_kwargs` instead of '
+                            '`related_url_kwargs` when using the Flask extension.')
+
+        self_view = kwargs.pop('self_view', None)
+        self_view_kwargs = kwargs.pop('self_view_kwargs', dict())
+        related_view = kwargs.pop('related_view', None)
+        related_view_kwargs = kwargs.pop('related_view_kwargs', dict())
+
+        if self_view_kwargs and not self_view:
+            raise ValueError('Must specify `self_view` keyword when '
+                             '`self_view_kwargs` is specified.')
+
+        if related_view_kwargs and not related_view:
+            raise ValueError('Must specify `related_view` keyword when '
+                             '`related_view_kwargs` is specified.')
+
+        if self_view:
+            kwargs['self_url'] = flask.url_for(self_view, **self_view_kwargs)
+        if related_view:
+            kwargs['related_url'] = flask.url_for(related_view,
+                                                  **related_view_kwargs)
+
+        super(Schema, self).__init__(*args, **kwargs)
+
+
     def generate_url(self, view_name, **kwargs):
         """Generate URL with any kwargs interpolated."""
         return flask.url_for(view_name, **kwargs) if view_name else None

--- a/marshmallow_jsonapi/flask.py
+++ b/marshmallow_jsonapi/flask.py
@@ -95,7 +95,6 @@ class Schema(DefaultSchema):
 
         super(Schema, self).__init__(*args, **kwargs)
 
-
     def generate_url(self, view_name, **kwargs):
         """Generate URL with any kwargs interpolated."""
         return flask.url_for(view_name, **kwargs) if view_name else None

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -85,6 +85,7 @@ class Schema(ma.Schema):
 
     def __init__(self, *args, **kwargs):
         self.include_data = kwargs.pop('include_data', ())
+        self.resource_identifier = kwargs.pop('resource_identifier', False)
         super(Schema, self).__init__(*args, **kwargs)
         if self.include_data:
             self.check_relations(self.include_data)
@@ -364,13 +365,19 @@ class Schema(ma.Schema):
                         ret['relationships'] = self.dict_class()
                     ret['relationships'][self.inflect(field_name)] = value
             else:
+                # Resource identifier objects don't get attributes.
+                if self.resource_identifier:
+                    continue
+
                 if 'attributes' not in ret:
                     ret['attributes'] = self.dict_class()
                 ret['attributes'][self.inflect(field_name)] = value
 
-        links = self.get_resource_links(item)
-        if links:
-            ret['links'] = links
+        # Resource identifier objects don't get links
+        if not self.resource_identifier:
+            links = self.get_resource_links(item)
+            if links:
+                ret['links'] = links
         return ret
 
     def format_items(self, data, many):

--- a/tests/base.py
+++ b/tests/base.py
@@ -48,7 +48,12 @@ class AuthorSchema(Schema):
             self_link = '/authors/'
         else:
             self_link = '/authors/{}'.format(data['id'])
-        return {'self': self_link}
+        links = {'self': self_link}
+
+        schema_links = super(AuthorSchema, self).get_top_level_links(data, many)
+        links.update(schema_links)
+
+        return links
 
     class Meta:
         type_ = 'people'

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -112,6 +112,34 @@ class TestResponseFormatting:
         assert 'links' in data
         assert data['links']['self'] == '/authors/'
 
+    def test_dump_single_resource_identifer(self, author):
+        data = unpack(AuthorSchema(resource_identifier=True).dump(author))
+
+        assert data == {
+            'data': {'id': str(author.id), 'type': 'people'},
+            'links': {'self': '/authors/' + str(author.id)}
+        }
+
+    def test_dump_many_resource_identifer(self, authors):
+        schema = AuthorSchema(many=True, resource_identifier=True)
+        data = unpack(schema.dump(authors))
+
+        assert set(data.keys()) == {'data', 'links'}
+        assert data['links'] == {'self': '/authors/'}
+        for i, author in enumerate(authors):
+            assert data['data'][i] == {'id': str(authors[i].id), 'type': 'people'}
+
+    def test_dump_none_resource_identifier(self):
+        data = unpack(AuthorSchema(resource_identifier=True).dump(None))
+
+        assert 'data' in data
+        assert data['data'] is None
+        assert 'links' not in data
+
+    def test_dump_empty_list_resource_identifier(self):
+        data = unpack(AuthorSchema(many=True, resource_identifier=True).dump([]))
+        assert data == {'data': [], 'links': {'self': '/authors/'}}
+
 
 class TestCompoundDocuments:
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -752,3 +752,24 @@ class TestRelationshipLoading(object):
 
         assert assert_relationship_error('author', errors['errors'])
         assert assert_relationship_error('comments', errors['errors'])
+
+
+class TestOverrideUrls(object):
+    def test_self_url(self, author):
+        url = '/articles/1/author'
+        schema = AuthorSchema(self_url=url)
+        data = unpack(schema.dump(author))
+
+        assert data['links']['self'] == url
+
+    def test_related_url(self, author):
+        self_url = '/articles/1/relationships/author'
+        related_url = '/articles/1/author'
+        schema = AuthorSchema(
+            resource_identifier=True,
+            self_url=self_url,
+            related_url=related_url)
+        data = unpack(schema.dump(author))
+
+        assert data['links']['self'] == self_url
+        assert data['links']['related'] == related_url


### PR DESCRIPTION
**Still needs documentation, do not merge.**

This PR adds a `resource_identifier` keyword argument to `Schema` to dump [resource identifier objects](http://jsonapi.org/format/#document-resource-identifier-objects), as you would at a relationships endpoint, e.g. `/users/<user_id>/relationships/articles`.

In cases like this, both `self` and `related` URLs are different from the `ArticleSchema` we'd use to dump the data.

```python
schema = ArticleSchema(
    many=True,
    resource_identifier=True,
    self_url='/users/1/relationships/articles',
    related_url='/users/1/articles',
)
```

The Flask extension uses views:

```python
from flask import request

@app.route('/users/<int:user_id>/relationships/articles')
def user_articles_relationship(user_id):
    schema = ArticleSchema(
        many=True,
        resource_identifier=True,
        self_view=request.endpoint,
        self_view_kwargs=request.view_args,
        related_view='user_articles',
        related_view_kwargs={'user_id': user_id},
    )
```

The logic for this was put into `get_top_level_links`, like was done when the `self_url` and `self_url_many` options were added.