### PR TITLE
Fix error that didn't match JSONAPI spec

### DIFF
--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -149,7 +149,12 @@ class Schema(ma.Schema):
     @ma.pre_load(pass_many=True)
     def unwrap_request(self, data, many):
         if 'data' not in data:
-            raise ma.ValidationError('Object must include `data` key.')
+            raise ma.ValidationError([{
+                'detail': 'Object must include `data` key.',
+                'source': {
+                    'pointer': '/',
+                },
+            }])
 
         data = data['data']
         if many:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -341,6 +341,23 @@ class TestErrorFormatting:
             errors = AuthorSchema(strict=False).validate(author)
             assert errors == expected
 
+    def test_validate_no_data_raises_error(self):
+        author = {'meta': {'this': 'that'}}
+        errors = AuthorSchema().validate(author)
+
+        expected = {
+            'errors': [
+                {
+                    'detail': 'Object must include `data` key.',
+                    'source': {
+                        'pointer': '/'
+                    }
+                }
+            ]
+        }
+
+        assert errors == expected
+
     def test_validate_type(self):
         author = {'data':
                 {'type': 'invalid', 'attributes': {'first_name': 'Dan', 'password': 'supersecure'}}}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -343,7 +343,11 @@ class TestErrorFormatting:
 
     def test_validate_no_data_raises_error(self):
         author = {'meta': {'this': 'that'}}
-        errors = AuthorSchema().validate(author)
+
+        with pytest.raises(ValidationError) as excinfo:
+            AuthorSchema(strict=True).validate(author)
+
+        errors = excinfo.value.messages
 
         expected = {
             'errors': [


### PR DESCRIPTION
Before this fix, the error object looked like this:

    {'errors': ['Object must include `data` key.']}