### PR TITLE
Bug Fix for Issue 67

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,3 +19,4 @@ Contributors (chronological)
 - Brandon Wood `@woodb <https://github.com/woodb>`_
 - Frazer McLean `@RazerM <https://github.com/RazerM>`_
 - J Rob Gant `@rgant <https://github.com/rgant>`_
+- Dan Poland `@danpoland <https://github.com/danpoland>`_

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -104,7 +104,7 @@ class Relationship(BaseRelationship):
         if isinstance(self.__schema, SchemaABC):
             return self.__schema
         if isinstance(self.__schema, type) and issubclass(self.__schema, SchemaABC):
-            self.__schema = self.__schema(many=self.many)
+            self.__schema = self.__schema()
             return self.__schema
         if isinstance(self.__schema, basestring):
             if self.__schema == _RECURSIVE_NESTED:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -262,6 +262,25 @@ class TestCompoundDocuments:
         for child in data['included']:
             assert child['attributes']['data'] == 'data%s' % child['id']
 
+    def test_include_data_with_many_and_schema_as_class(self, post):
+        class PostClassSchema(PostSchema):
+            post_comments = fields.Relationship(
+                'http://test.test/posts/{id}/comments/',
+                related_url_kwargs={'id': '<id>'},
+                attribute='comments', dump_to='post-comments',
+                schema=CommentSchema, many=True
+            )
+
+            class Meta(PostSchema.Meta):
+                pass
+
+        data = PostClassSchema(include_data=('post_comments',)).dump(post).data
+        assert 'included' in data
+        assert len(data['included']) == 2
+        first_comment = data['included'][0]
+        assert 'attributes' in first_comment
+        assert 'body' in first_comment['attributes']
+
 
 def get_error_by_field(errors, field):
     for err in errors['errors']:


### PR DESCRIPTION
Bug fix for https://github.com/marshmallow-code/marshmallow-jsonapi/issues/67.

> When the schema argument to the Relationship field is a class reference and many=True, the schema property on the Relationship instance incorrectly initializes the schema class with many=True. It does not need to be set at all. The _serialize method iterates over each item in the included_data. This bug causes a TypeError to be thrown because the object being serialized is not an iterable.