### PR TITLE
Support for "link objects"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ _sandbox
 env
 venv
 .python-version
+
+# Pycharm
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,3 @@ _sandbox
 env
 venv
 .python-version
-
-# Pycharm
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ _sandbox
 env
 venv
 .python-version
+
+
+# Pycharm
+.idea/

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -86,7 +86,10 @@ class Relationship(BaseRelationship):
         many=False, type_=None, id_field=None, **kwargs
     ):
         if related_meta:
-            assert callable(related_meta), 'related_meta must be a callable.'
+            if not related_url:
+                raise ValueError('related_meta requires the related_url argument.')
+            if not callable(related_meta):
+                raise ValueError('related_meta must be a callable.')
 
         self.related_url = related_url
         self.related_url_kwargs = related_url_kwargs or {}
@@ -197,7 +200,8 @@ class Relationship(BaseRelationship):
             if related_url:
                 if self.related_meta:
                     meta = self.related_meta(value)
-                    assert isinstance(meta, dict_class), 'related_meta must return a dict.'
+                    if not isinstance(meta, dict_class):
+                        raise ValueError('related_meta must return a dict.')
                     ret['links']['related'] = {'href': related_url, 'meta': meta}
                 else:
                     ret['links']['related'] = related_url

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -207,7 +207,7 @@ class Relationship(BaseRelationship):
                     meta = self.self_meta(value)
                     if not isinstance(meta, dict_class):
                         raise ValueError('self_meta must return a dict.')
-                    ret['links']['self'] = {'href': self_url, 'meta': meta}
+                    ret['links']['self'] = dict_class(href=self_url, meta=meta)
                 else:
                     ret['links']['self'] = self_url
             if related_url:
@@ -215,7 +215,7 @@ class Relationship(BaseRelationship):
                     meta = self.related_meta(value)
                     if not isinstance(meta, dict_class):
                         raise ValueError('related_meta must return a dict.')
-                    ret['links']['related'] = {'href': related_url, 'meta': meta}
+                    ret['links']['related'] = dict_class(href=related_url, meta=meta)
                 else:
                     ret['links']['related'] = related_url
 

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -232,7 +232,7 @@ class Schema(ma.Schema):
             container = 'attributes'
 
         inflected_name = self.inflect(field_name)
-        if index:
+        if index is not None:
             pointer = '/data/{}/{}/{}'.format(index, container, inflected_name)
         else:
             pointer = '/data/{}/{}'.format(container, inflected_name)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -253,6 +253,42 @@ class TestGenericRelationshipField:
         with pytest.raises(ValueError):
             field.serialize('comments', post)
 
+    def test_self_meta(self, post):
+        def get_meta(value):
+            return {'test': 'test'}
+
+        field = Relationship(
+            self_url='/posts/{post_id}/relationships/comments',
+            self_url_kwargs={'post_id': '<id>'},
+            self_meta=get_meta,
+        )
+        result = field.serialize('comments', post)
+
+        assert result['links']['self']['href']
+        assert result['links']['self']['meta'] == {'test': 'test'}
+
+    def test_self_meta_missing_self_url(self, post):
+        def get_meta(value):
+            return {'test': 'test'}
+
+        with pytest.raises(ValueError):
+            Relationship(
+                self_meta=get_meta,
+            )
+
+    def test_self_meta_bad_return(self, post):
+        def get_meta(value):
+            return 'test'
+
+        field = Relationship(
+            self_url='/posts/{post_id}/relationships/comments',
+            self_url_kwargs={'post_id': '<id>'},
+            self_meta=get_meta,
+        )
+
+        with pytest.raises(ValueError):
+            field.serialize('comments', post)
+
 
 class TestMetaField:
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -211,6 +211,48 @@ class TestGenericRelationshipField:
         assert result and result['links']['related']
         assert 'data' not in result
 
+    def test_include_meta(self, post):
+        def get_count(value):
+            return {'count': len(value)}
+
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            related_meta=get_count,
+            many=True,
+            include_resource_linkage=False
+        )
+        result = field.serialize('comments', post)
+
+        assert result['links']['related']['href']
+        assert result['links']['related']['meta'] == {'count': 2}
+
+    def test_include_meta_missing_related_url(self, post):
+        def get_count(value):
+            return {'count': len(value)}
+
+        with pytest.raises(ValueError):
+            Relationship(
+                related_meta=get_count,
+                many=True,
+                include_resource_linkage=False
+            )
+
+    def test_include_meta_bad_return(self, post):
+        def get_count(value):
+            return len(value)
+
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            related_meta=get_count,
+            many=True,
+            include_resource_linkage=False
+        )
+
+        with pytest.raises(ValueError):
+            field.serialize('comments', post)
+
 
 class TestMetaField:
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -417,8 +417,8 @@ class TestErrorFormatting:
 
     def test_errors_many(self):
         authors = make_authors([
-            {'first_name': 'Dan', 'last_name': 'Gebhardt', 'password': 'supersecret'},
             {'first_name': 'Dan', 'last_name': 'Gebhardt', 'password': 'bad'},
+            {'first_name': 'Dan', 'last_name': 'Gebhardt', 'password': 'supersecret'},
         ])
         errors = AuthorSchema(many=True).validate(authors)['errors']
 
@@ -426,7 +426,7 @@ class TestErrorFormatting:
 
         err = errors[0]
         assert 'source' in err
-        assert err['source']['pointer'] == '/data/1/attributes/password'
+        assert err['source']['pointer'] == '/data/0/attributes/password'
 
 def dasherize(text):
     return text.replace('_', '-')


### PR DESCRIPTION
This PR adds support for link objects. See: https://github.com/marshmallow-code/marshmallow-jsonapi/issues/72

I added arguments to the Relationship field (self_meta, related_meta) that allow you to register callables for returning meta information about a link. The callables must return a dictionary like object. This allows you to end up with a serialized relationship object that looks like:

```
"relationships": {
  "users": {
    "links": {
      "related": {
        "href": "/accounts/1/users/",
        "meta": {
          "count": 25
        }
      }
    }
  }
}