### PR TITLE
Use Schema.get_attribute rather than utils.get_value in Relationship

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,3 +20,4 @@ Contributors (chronological)
 - Frazer McLean `@RazerM <https://github.com/RazerM>`_
 - J Rob Gant `@rgant <https://github.com/rgant>`_
 - Dan Poland `@danpoland <https://github.com/danpoland>`_
+- Mark Hall `@scmmmh<https://github.com/scmmmh>`_

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -12,7 +12,7 @@ from marshmallow.fields import *  # noqa
 from marshmallow.base import SchemaABC
 from marshmallow.utils import is_collection
 
-from .utils import get_value, resolve_params, iteritems
+from .utils import resolve_params, iteritems
 
 
 _RECURSIVE_NESTED = 'self'
@@ -134,12 +134,12 @@ class Relationship(BaseRelationship):
         if self.many:
             resource_object = [{
                 'type': self.type_,
-                'id': _stringify(get_value(each, self.id_field, each))
+                'id': _stringify(self.schema.get_attribute(each, self.id_field, each))
             } for each in value]
         else:
             resource_object = {
                 'type': self.type_,
-                'id': _stringify(get_value(value, self.id_field, value))
+                'id': _stringify(self.schema.get_attribute(value, self.id_field, value))
             }
         return resource_object
 

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -101,7 +101,6 @@ class Relationship(BaseRelationship):
 
     @property
     def schema(self):
-        print(self.__schema.__class__)
         if isinstance(self.__schema, SchemaABC):
             return self.__schema
         if isinstance(self.__schema, type) and issubclass(self.__schema, SchemaABC):

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -12,7 +12,7 @@ from marshmallow.fields import *  # noqa
 from marshmallow.base import SchemaABC
 from marshmallow.utils import is_collection
 
-from .utils import resolve_params, iteritems, _MARSHMALLOW_VERSION_INFO
+from .utils import get_value, resolve_params, iteritems, _MARSHMALLOW_VERSION_INFO
 
 
 _RECURSIVE_NESTED = 'self'
@@ -134,16 +134,12 @@ class Relationship(BaseRelationship):
         if self.many:
             resource_object = [{
                 'type': self.type_,
-                'id': _stringify(self.schema.get_attribute(each, self.id_field, each)
-                                 if _MARSHMALLOW_VERSION_INFO[0] >= 3
-                                 else self.schema.get_attribute(self.id_field, each, each))
+                'id': _stringify(self._get_id(each))
             } for each in value]
         else:
             resource_object = {
                 'type': self.type_,
-                'id': _stringify(self.schema.get_attribute(value, self.id_field, value)
-                                 if _MARSHMALLOW_VERSION_INFO[0] >= 3
-                                 else self.schema.get_attribute(self.id_field, value, value))
+                'id': _stringify(self._get_id(value))
             }
         return resource_object
 
@@ -218,6 +214,18 @@ class Relationship(BaseRelationship):
         self.root.included_data[(item['type'], item['id'])] = item
         for key, value in iteritems(self.schema.included_data):
             self.root.included_data[key] = value
+
+    def _get_id(self, value):
+        if _MARSHMALLOW_VERSION_INFO[0] >= 3:
+            try:
+                return self.schema.get_attribute(value, self.id_field, value)
+            except ValueError:
+                return get_value(value, self.id_field, value)
+        else:
+            try:
+                return self.schema.get_attribute(self.id_field, value, value)
+            except ValueError:
+                return get_value(value, self.id_field, value)
 
 
 class Meta(Field):

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -101,6 +101,7 @@ class Relationship(BaseRelationship):
 
     @property
     def schema(self):
+        print(self.__schema.__class__)
         if isinstance(self.__schema, SchemaABC):
             return self.__schema
         if isinstance(self.__schema, type) and issubclass(self.__schema, SchemaABC):
@@ -134,12 +135,12 @@ class Relationship(BaseRelationship):
         if self.many:
             resource_object = [{
                 'type': self.type_,
-                'id': _stringify(self.schema.get_attribute(each, self.id_field, each))
+                'id': _stringify(self.schema.get_attribute(self.id_field, each, each))
             } for each in value]
         else:
             resource_object = {
                 'type': self.type_,
-                'id': _stringify(self.schema.get_attribute(value, self.id_field, value))
+                'id': _stringify(self.schema.get_attribute(self.id_field, value, value))
             }
         return resource_object
 

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -217,14 +217,14 @@ class Relationship(BaseRelationship):
 
     def _get_id(self, value):
         if _MARSHMALLOW_VERSION_INFO[0] >= 3:
-            try:
+            if self.__schema:
                 return self.schema.get_attribute(value, self.id_field, value)
-            except ValueError:
+            else:
                 return get_value(value, self.id_field, value)
         else:
-            try:
+            if self.__schema:
                 return self.schema.get_attribute(self.id_field, value, value)
-            except ValueError:
+            else:
                 return get_value(value, self.id_field, value)
 
 

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -12,7 +12,7 @@ from marshmallow.fields import *  # noqa
 from marshmallow.base import SchemaABC
 from marshmallow.utils import is_collection
 
-from .utils import resolve_params, iteritems
+from .utils import resolve_params, iteritems, _MARSHMALLOW_VERSION_INFO
 
 
 _RECURSIVE_NESTED = 'self'
@@ -135,12 +135,16 @@ class Relationship(BaseRelationship):
         if self.many:
             resource_object = [{
                 'type': self.type_,
-                'id': _stringify(self.schema.get_attribute(self.id_field, each, each))
+                'id': _stringify(self.schema.get_attribute(each, self.id_field, each)
+                                 if _MARSHMALLOW_VERSION_INFO[0] >= 3
+                                 else self.schema.get_attribute(self.id_field, each, each))
             } for each in value]
         else:
             resource_object = {
                 'type': self.type_,
-                'id': _stringify(self.schema.get_attribute(self.id_field, value, value))
+                'id': _stringify(self.schema.get_attribute(value, self.id_field, value)
+                                 if _MARSHMALLOW_VERSION_INFO[0] >= 3
+                                 else self.schema.get_attribute(self.id_field, value, value))
             }
         return resource_object
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -16,3 +16,6 @@ class Author(Bunch):
 
 class Comment(Bunch):
     pass
+
+class Keyword(Bunch):
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,25 +1,31 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from tests.base import Author, Post, Comment, fake
+from tests.base import Author, Post, Comment, Keyword, fake
 
 def make_author():
     return Author(id=fake.random_int(), first_name=fake.first_name(),
                   last_name=fake.last_name(), twitter=fake.domain_word())
 
-def make_post(with_comments=True, with_author=True):
+def make_post(with_comments=True, with_author=True, with_keywords=True):
     comments = [make_comment() for _ in range(2)] if with_comments else []
+    keywords = [make_keyword() for _ in range(3)] if with_keywords else []
     author = make_author() if with_author else None
     return Post(
         id=fake.random_int(),
         title=fake.catch_phrase(),
         author=author,
         author_id=author.id if with_author else None,
-        comments=comments)
+        comments=comments,
+        keywords=keywords)
 
 def make_comment(with_author=True):
     author = make_author() if with_author else None
     return Comment(id=fake.random_int(), body=fake.bs(), author=author)
+
+def make_keyword():
+    return Keyword(keyword=fake.domain_word())
+
 
 @pytest.fixture()
 def author():

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from hashlib import md5
 from marshmallow import ValidationError
 from marshmallow_jsonapi.fields import Meta, Relationship
 
@@ -97,6 +98,17 @@ class TestGenericRelationshipField:
         assert 'data' in result
         ids = [each['id'] for each in result['data']]
         assert ids == [str(each.id) for each in post.comments]
+
+    def test_include_resource_linkage_many_with_schema_overriding_get_attribute(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/keywords',
+            related_url_kwargs={'post_id': '<id>'},
+            many=True, include_resource_linkage=True, type_='keywords', schema='KeywordSchema'
+        )
+        result = field.serialize('keywords', post)
+        assert 'data' in result
+        ids = [each['id'] for each in result['data']]
+        assert ids == [md5(each.keyword.encode('utf-8')).hexdigest() for each in post.keywords]
 
     def test_deserialize_data_single(self, post):
         field = Relationship(

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -40,6 +40,17 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/author/',
             related_url_kwargs={'post_id': '<id>'},
+            include_resource_linkage=True, type_='people'
+        )
+        result = field.serialize('author', post)
+        assert 'data' in result
+        assert result['data']
+        assert result['data']['id'] == str(post.author.id)
+
+    def test_include_resource_linkage_single_with_schema(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/author/',
+            related_url_kwargs={'post_id': '<id>'},
             include_resource_linkage=True, type_='people', schema='PostSchema'
         )
         result = field.serialize('author', post)
@@ -51,12 +62,32 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/author/',
             related_url_kwargs={'post_id': '<id>'},
+            include_resource_linkage=True, type_='people'
+        )
+        result = field.serialize('author_id', post)
+        assert result['data']['id'] == str(post.author_id)
+
+    def test_include_resource_linkage_single_foreign_key_with_schema(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/author/',
+            related_url_kwargs={'post_id': '<id>'},
             include_resource_linkage=True, type_='people', schema='PostSchema'
         )
         result = field.serialize('author_id', post)
         assert result['data']['id'] == str(post.author_id)
 
     def test_include_resource_linkage_many(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=True, include_resource_linkage=True, type_='comments'
+        )
+        result = field.serialize('comments', post)
+        assert 'data' in result
+        ids = [each['id'] for each in result['data']]
+        assert ids == [str(each.id) for each in post.comments]
+
+    def test_include_resource_linkage_many_with_schema(self, post):
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -40,7 +40,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/author/',
             related_url_kwargs={'post_id': '<id>'},
-            include_resource_linkage=True, type_='people'
+            include_resource_linkage=True, type_='people', schema='PostSchema'
         )
         result = field.serialize('author', post)
         assert 'data' in result
@@ -51,7 +51,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/author/',
             related_url_kwargs={'post_id': '<id>'},
-            include_resource_linkage=True, type_='people'
+            include_resource_linkage=True, type_='people', schema='PostSchema'
         )
         result = field.serialize('author_id', post)
         assert result['data']['id'] == str(post.author_id)
@@ -60,7 +60,7 @@ class TestGenericRelationshipField:
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
-            many=True, include_resource_linkage=True, type_='comments'
+            many=True, include_resource_linkage=True, type_='comments', schema='CommentSchema'
         )
         result = field.serialize('comments', post)
         assert 'data' in result

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -75,9 +75,9 @@ class KeywordSchema(Schema):
     def get_attribute(self, attr, obj, default):
         if attr == 'id':
             if _MARSHMALLOW_VERSION_INFO[0] >= 3:
-                return md5(super(Schema, self).get_attribute(obj, 'keyword', obj).encode('utf-8')).hexdigest()
-            else:
                 return md5(super(Schema, self).get_attribute('keyword', obj, obj).encode('utf-8')).hexdigest()
+            else:
+                return md5(super(Schema, self).get_attribute(obj, 'keyword', obj).encode('utf-8')).hexdigest()
         else:
             return super(Schema, self).get_attribute(attr, obj, default)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -75,9 +75,9 @@ class KeywordSchema(Schema):
     def get_attribute(self, attr, obj, default):
         if attr == 'id':
             if _MARSHMALLOW_VERSION_INFO[0] >= 3:
-                return md5(super(Schema, self).get_attribute('keyword', obj, obj).encode('utf-8')).hexdigest()
-            else:
                 return md5(super(Schema, self).get_attribute(obj, 'keyword', obj).encode('utf-8')).hexdigest()
+            else:
+                return md5(super(Schema, self).get_attribute('keyword', obj, obj).encode('utf-8')).hexdigest()
         else:
             return super(Schema, self).get_attribute(attr, obj, default)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -74,7 +74,10 @@ class KeywordSchema(Schema):
 
     def get_attribute(self, attr, obj, default):
         if attr == 'id':
-            return md5(super(Schema, self).get_attribute('keyword', obj, '').encode('utf-8')).hexdigest()
+            if _MARSHMALLOW_VERSION_INFO[0] >= 3:
+                return md5(super(Schema, self).get_attribute(obj, 'keyword', obj).encode('utf-8')).hexdigest()
+            else:
+                return md5(super(Schema, self).get_attribute('keyword', obj, obj).encode('utf-8')).hexdigest()
         else:
             return super(Schema, self).get_attribute(attr, obj, default)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from hashlib import md5
 from marshmallow import validate, ValidationError
 from marshmallow_jsonapi import Schema, fields
 from marshmallow_jsonapi.exceptions import IncorrectTypeError
@@ -42,6 +43,13 @@ class PostSchema(Schema):
         schema='CommentSchema', many=True
     )
 
+    post_keywords= fields.Relationship(
+        'http://test.test/posts/{id}/keywords/',
+        related_url_kwargs={'id': '<id>'},
+        attribute='keywords', dump_to='post-keywords',
+        schema='KeywordSchema', many=True
+    )
+
     class Meta:
         type_ = 'posts'
 
@@ -58,6 +66,20 @@ class CommentSchema(Schema):
 
     class Meta:
         type_ = 'comments'
+
+
+class KeywordSchema(Schema):
+    id = fields.Str()
+    keyword = fields.Str(required=True)
+
+    def get_attribute(self, attr, obj, default):
+        if attr == 'id':
+            return md5(super(Schema, self).get_attribute('keyword', obj, '').encode('utf-8')).hexdigest()
+        else:
+            return super(Schema, self).get_attribute(attr, obj, default)
+
+    class Meta:
+        type_ = 'keywords'
 
 
 def test_type_is_required():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -74,10 +74,7 @@ class KeywordSchema(Schema):
 
     def get_attribute(self, attr, obj, default):
         if attr == 'id':
-            if _MARSHMALLOW_VERSION_INFO[0] >= 3:
-                return md5(super(Schema, self).get_attribute(obj, 'keyword', obj).encode('utf-8')).hexdigest()
-            else:
-                return md5(super(Schema, self).get_attribute('keyword', obj, obj).encode('utf-8')).hexdigest()
+            return md5(super(Schema, self).get_attribute('keyword', obj, obj).encode('utf-8')).hexdigest()
         else:
             return super(Schema, self).get_attribute(attr, obj, default)
 


### PR DESCRIPTION
When using include_resource_linkage in relationships the code used utils.get_value to get the "id" attribute's value. However, I believe that it should use the link Schema's get_attribute method to enable schemas to override how the attribute is accessed (as is the case for all scalar attributes).

If the Schema's get_attribute has not been overridden, then this will change nothing in the code's behaviour. If it has been overridden, then the behaviour is now consistent.

Works for both marshmallow < 3 and >=3, but includes an at-runtime check for the marshmallow version. Not the most elegant solution, but I am stuck for anything else.

As far as I can see would fix #53.