### PR TITLE
Use default attribute value instead of raising exception if relationship is none on Relationship field

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,3 +20,4 @@ Contributors (chronological)
 - Frazer McLean `@RazerM <https://github.com/RazerM>`_
 - J Rob Gant `@rgant <https://github.com/rgant>`_
 - Dan Poland `@danpoland <https://github.com/danpoland>`_
+- Pierre CHAISY `@akira-dev <https://github.com/akira-dev>`_

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -120,14 +120,24 @@ class Relationship(BaseRelationship):
 
     def get_related_url(self, obj):
         if self.related_url:
-            kwargs = resolve_params(obj, self.related_url_kwargs)
-            return self.related_url.format(**kwargs)
+            params = resolve_params(obj, self.related_url_kwargs, default=self.default)
+            non_null_params = {
+                key: value for key, value in params.items()
+                if value is not None
+            }
+            if non_null_params:
+                return self.related_url.format(**non_null_params)
         return None
 
     def get_self_url(self, obj):
         if self.self_url:
-            kwargs = resolve_params(obj, self.self_url_kwargs)
-            return self.self_url.format(**kwargs)
+            params = resolve_params(obj, self.self_url_kwargs, default=self.default)
+            non_null_params = {
+                key: value for key, value in params.items()
+                if value is not None
+            }
+            if non_null_params:
+                return self.self_url.format(**non_null_params)
         return None
 
     def get_resource_linkage(self, value):

--- a/marshmallow_jsonapi/flask.py
+++ b/marshmallow_jsonapi/flask.py
@@ -109,7 +109,7 @@ class Relationship(GenericRelationship):
 
     def get_url(self, obj, view_name, view_kwargs):
         if view_name:
-            kwargs = resolve_params(obj, view_kwargs)
+            kwargs = resolve_params(obj, view_kwargs, default=self.default)
             kwargs['endpoint'] = view_name
             try:
                 return flask.url_for(**kwargs)

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -276,9 +276,10 @@ class Schema(ma.Schema):
                     ret['meta'] = self.dict_class()
                 ret['meta'].update(value)
             elif isinstance(self.fields[attribute], BaseRelationship):
-                if 'relationships' not in ret:
-                    ret['relationships'] = self.dict_class()
-                ret['relationships'][self.inflect(field_name)] = value
+                if value:
+                    if 'relationships' not in ret:
+                        ret['relationships'] = self.dict_class()
+                    ret['relationships'][self.inflect(field_name)] = value
             else:
                 if 'attributes' not in ret:
                     ret['attributes'] = self.dict_class()

--- a/marshmallow_jsonapi/utils.py
+++ b/marshmallow_jsonapi/utils.py
@@ -27,7 +27,7 @@ def tpl(val):
         return match.groups()[0]
     return None
 
-def resolve_params(obj, params):
+def resolve_params(obj, params, default=missing):
     """Given a dictionary of keyword arguments, return the same dictionary except with
     values enclosed in `< >` resolved to attributes on `obj`.
     """
@@ -35,7 +35,7 @@ def resolve_params(obj, params):
     for name, attr_tpl in iteritems(params):
         attr_name = tpl(str(attr_tpl))
         if attr_name:
-            attribute_value = get_value(obj, attr_name, default=missing)
+            attribute_value = get_value(obj, attr_name, default=default)
             if attribute_value is not missing:
                 param_values[name] = attribute_value
             else:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -211,6 +211,16 @@ class TestGenericRelationshipField:
         assert result and result['links']['related']
         assert 'data' not in result
 
+    def test_empty_relationship_with_alternative_identifier_field(self, post_with_null_author):
+        field = Relationship(
+            related_url='/authors/{author_id}',
+            related_url_kwargs={'author_id': '<author.last_name>'},
+            default=None
+        )
+        result = field.serialize('author', post_with_null_author)
+
+        assert not result
+
 
 class TestMetaField:
 


### PR DESCRIPTION
I can't compute a related relationship url if relationship is none and related_kwargs include a dot.
Example:

```python
    item = Relationship(related_view='item_detail',
                        related_view_kwargs={'id': '<item.identifier>'},
                        schema='ItemSchema',
                        id_field='identifier',
                        type_='item')
```
In this case relationship is none so my_object.item is None and I receive an error:
AttributeError: 'item.identifier' is not a valid attribute of <Item object>

But 'item.identifier' is a valid attribut of my_object but the relationship is not mandatory so my_object.item could be None.

So I would like to use the default attribute of a field to set the value return by the serialization of the relationship field instead of the exception.

Plus if the default value is None I would like to get the same behavior for a relationship field as any other field so the relationship links are not included to the result.

Do you think it is the right way or I missed something ?