### PR TITLE
Issue 76 Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ _sandbox
 env
 venv
 .python-version
+
+
+# Pycharm
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,3 @@ _sandbox
 env
 venv
 .python-version
-
-
-# Pycharm
-.idea/

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -232,7 +232,7 @@ class Schema(ma.Schema):
             container = 'attributes'
 
         inflected_name = self.inflect(field_name)
-        if index:
+        if index is not None:
             pointer = '/data/{}/{}/{}'.format(index, container, inflected_name)
         else:
             pointer = '/data/{}/{}'.format(container, inflected_name)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -417,8 +417,8 @@ class TestErrorFormatting:
 
     def test_errors_many(self):
         authors = make_authors([
-            {'first_name': 'Dan', 'last_name': 'Gebhardt', 'password': 'supersecret'},
             {'first_name': 'Dan', 'last_name': 'Gebhardt', 'password': 'bad'},
+            {'first_name': 'Dan', 'last_name': 'Gebhardt', 'password': 'supersecret'},
         ])
         errors = AuthorSchema(many=True).validate(authors)['errors']
 
@@ -426,7 +426,7 @@ class TestErrorFormatting:
 
         err = errors[0]
         assert 'source' in err
-        assert err['source']['pointer'] == '/data/1/attributes/password'
+        assert err['source']['pointer'] == '/data/0/attributes/password'
 
 def dasherize(text):
     return text.replace('_', '-')


### PR DESCRIPTION
Schema.format_error incorrectly checks if index is falsely, when 0 (zero) is a valid index and should be used when formatting the pointer.

https://github.com/marshmallow-code/marshmallow-jsonapi/issues/76