### PR TITLE
Use Schema.get_attribute rather than utils.get_value in Relationship

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,3 +22,4 @@ Contributors (chronological)
 - Dan Poland `@danpoland <https://github.com/danpoland>`_
 - Pierre CHAISY `@akira-dev <https://github.com/akira-dev>`_
 - `@mrhanky17 <https://github.com/mrhanky17>`_
+- Mark Hall `@scmmmh <https://github.com/scmmmh>`_

--- a/tests/base.py
+++ b/tests/base.py
@@ -16,3 +16,6 @@ class Author(Bunch):
 
 class Comment(Bunch):
     pass
+
+class Keyword(Bunch):
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,25 +1,31 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from tests.base import Author, Post, Comment, fake
+from tests.base import Author, Post, Comment, Keyword, fake
 
 def make_author():
     return Author(id=fake.random_int(), first_name=fake.first_name(),
                   last_name=fake.last_name(), twitter=fake.domain_word())
 
-def make_post(with_comments=True, with_author=True):
+def make_post(with_comments=True, with_author=True, with_keywords=True):
     comments = [make_comment() for _ in range(2)] if with_comments else []
+    keywords = [make_keyword() for _ in range(3)] if with_keywords else []
     author = make_author() if with_author else None
     return Post(
         id=fake.random_int(),
         title=fake.catch_phrase(),
         author=author,
         author_id=author.id if with_author else None,
-        comments=comments)
+        comments=comments,
+        keywords=keywords)
 
 def make_comment(with_author=True):
     author = make_author() if with_author else None
     return Comment(id=fake.random_int(), body=fake.bs(), author=author)
+
+def make_keyword():
+    return Keyword(keyword=fake.domain_word())
+
 
 @pytest.fixture()
 def author():

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from hashlib import md5
 from marshmallow import ValidationError
 from marshmallow_jsonapi.fields import Meta, Relationship
 
@@ -47,11 +48,31 @@ class TestGenericRelationshipField:
         assert result['data']
         assert result['data']['id'] == str(post.author.id)
 
+    def test_include_resource_linkage_single_with_schema(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/author/',
+            related_url_kwargs={'post_id': '<id>'},
+            include_resource_linkage=True, type_='people', schema='PostSchema'
+        )
+        result = field.serialize('author', post)
+        assert 'data' in result
+        assert result['data']
+        assert result['data']['id'] == str(post.author.id)
+
     def test_include_resource_linkage_single_foreign_key(self, post):
         field = Relationship(
             related_url='/posts/{post_id}/author/',
             related_url_kwargs={'post_id': '<id>'},
             include_resource_linkage=True, type_='people'
+        )
+        result = field.serialize('author_id', post)
+        assert result['data']['id'] == str(post.author_id)
+
+    def test_include_resource_linkage_single_foreign_key_with_schema(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/author/',
+            related_url_kwargs={'post_id': '<id>'},
+            include_resource_linkage=True, type_='people', schema='PostSchema'
         )
         result = field.serialize('author_id', post)
         assert result['data']['id'] == str(post.author_id)
@@ -66,6 +87,28 @@ class TestGenericRelationshipField:
         assert 'data' in result
         ids = [each['id'] for each in result['data']]
         assert ids == [str(each.id) for each in post.comments]
+
+    def test_include_resource_linkage_many_with_schema(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/comments',
+            related_url_kwargs={'post_id': '<id>'},
+            many=True, include_resource_linkage=True, type_='comments', schema='CommentSchema'
+        )
+        result = field.serialize('comments', post)
+        assert 'data' in result
+        ids = [each['id'] for each in result['data']]
+        assert ids == [str(each.id) for each in post.comments]
+
+    def test_include_resource_linkage_many_with_schema_overriding_get_attribute(self, post):
+        field = Relationship(
+            related_url='/posts/{post_id}/keywords',
+            related_url_kwargs={'post_id': '<id>'},
+            many=True, include_resource_linkage=True, type_='keywords', schema='KeywordSchema'
+        )
+        result = field.serialize('keywords', post)
+        assert 'data' in result
+        ids = [each['id'] for each in result['data']]
+        assert ids == [md5(each.keyword.encode('utf-8')).hexdigest() for each in post.keywords]
 
     def test_deserialize_data_single(self, post):
         field = Relationship(


### PR DESCRIPTION
I have closed the previous pull request as I was having trouble replicating the test environment locally, leading to a large number of messy commits. I have cleaned that up and got a working test environment, so here is the cleaner pull request:

When using include_resource_linkage in relationships the code used utils.get_value to get the "id" attribute's value. However, I believe that it should use the link Schema's get_attribute method to enable schemas to override how the attribute is accessed (as is the case for all scalar attributes).

If the Schema's get_attribute has not been overridden, then this will change nothing in the code's behaviour. If it has been overridden, then the behaviour is now consistent.

As far as I can see would fix #53.

I have added test cases covering the new functionality and one that would fail without the new functionality.