### PR TITLE
Add Tox environments for Marshmallow >=3 and <3

### DIFF
--- a/dev-requirements-marshmallow23.txt
+++ b/dev-requirements-marshmallow23.txt
@@ -15,3 +15,6 @@ twine
 
 # Syntax checking
 flake8==2.4.1
+
+# Force using Marshmallow < 3
+marshmallow>=2.3.0,<3

--- a/dev-requirements-marshmallow30.txt
+++ b/dev-requirements-marshmallow30.txt
@@ -1,0 +1,20 @@
+# Build tasks
+invoke==0.13.0
+
+# Soft deps
+Flask
+
+# Testing
+pytest>=2.7.3
+tox>=1.5.0
+faker
+
+# Packaging
+wheel
+twine
+
+# Syntax checking
+flake8==2.4.1
+
+# Force using Marshmallow >= 3
+marshmallow>=3.0.0a1

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist =py27,py34,py35,py36
+envlist ={py27,py34,py35,py36}-{marshmallow23,marshmallow30}
 [testenv]
 deps=
-    -rdev-requirements.txt
+    marshmallow23: -rdev-requirements-marshmallow23.txt
+    marshmallow30: -rdev-requirements-marshmallow30.txt
 commands=
     flake8 .
     py.test


### PR DESCRIPTION
This brings the tox.ini for local testing in line with the configuration used by Travis and allows for local testing with all python release version and marshmallow >=3 and < 3.