### PR TITLE
Relationship include_attribute support

### DIFF
--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -82,13 +82,14 @@ class Relationship(BaseRelationship):
         self,
         related_url='', related_url_kwargs=None,
         self_url='', self_url_kwargs=None,
-        include_resource_linkage=False, schema=None,
-        many=False, type_=None, id_field=None, **kwargs
+        include_attribute=None, include_resource_linkage=False,
+        schema=None, many=False, type_=None, id_field=None, **kwargs
     ):
         self.related_url = related_url
         self.related_url_kwargs = related_url_kwargs or {}
         self.self_url = self_url
         self.self_url_kwargs = self_url_kwargs or {}
+        self.include_attribute = include_attribute
         if include_resource_linkage and not type_:
             raise ValueError('include_resource_linkage=True requires the type_ argument.')
         self.many = many
@@ -198,12 +199,17 @@ class Relationship(BaseRelationship):
             else:
                 ret['data'] = self.get_resource_linkage(value)
 
-        if self.include_data and value is not None:
-            if self.many:
-                for item in value:
-                    self._serialize_included(item)
-            else:
-                self._serialize_included(value)
+        if self.include_data:
+            if self.include_attribute:
+                value = getattr(obj, self.include_attribute, None)
+
+            if value is not None:
+                if self.many:
+                    for item in value:
+                        self._serialize_included(item)
+                else:
+                    self._serialize_included(value)
+
         return ret
 
     def _serialize_included(self, value):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -33,7 +33,10 @@ class PostSchema(Schema):
     author = fields.Relationship(
         'http://test.test/posts/{id}/author/',
         related_url_kwargs={'id': '<id>'},
-        schema=AuthorSchema, many=False
+        schema=AuthorSchema,
+        many=False,
+        attribute='author_id',
+        include_attribute='author'
     )
 
     post_comments = fields.Relationship(


### PR DESCRIPTION
Add support for an include_attribute parameter on the Relationship field. Similar to the normal attribute parameter, this parameter allows you to specify an attribute on the object being serialized when the related object is to be included with the serialized output.

This is useful when you are serializing SQLAlchemy model objects and only want to join a related table when the data from that table will actually be included in the serialized results. When the related object data is not to be included you can use the attribute parameter to specify the foreign key on the model.

See https://github.com/marshmallow-code/marshmallow-jsonapi/issues/34.