### PR TITLE
Support loading included data into relationships

### DIFF
--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -165,6 +165,13 @@ class Relationship(BaseRelationship):
 
         if errors:
             raise ValidationError(errors)
+
+        # If ``attributes`` is set, we've folded included data into this
+        # relationship. Unserialize it if we have a schema set; otherwise we
+        # fall back below to old behaviour of only IDs.
+        if 'attributes' in data and self.__schema:
+            return self.schema.load({'data': data}).data
+
         return data.get('id')
 
     def deserialize(self, value, attr=None, data=None):


### PR DESCRIPTION
marshmallow-jsonapi supported serializing with included data, but not
deserializing. This patch adds support for loading included data during
deserialization.

No changes are needed ot get this behaviour, and it is intended to be
as backwards-compatible as possible. If a payload with included data is
loaded and a related relationship with a schema is defined, then the
items that belongs to the relationship will be deserialized from the
included data into the attributes defined by the relationship.
Relationships without a schema set, or loading without any included
data, behaves just as before by deserializing to a list of IDs.

Implements #83 