### PR TITLE
Move meta information object to document top level

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -234,11 +234,15 @@ meta object within a `resource object <http://jsonapi.org/format/#document-resou
     author = {'name': 'Alice', 'metadata': {'page': {'offset': 10}}}
     AuthorSchema().dump(author).data
     # {
+    #     "meta": {
+    #         "page": {
+    #             "offset": 10
+    #         }
+    #     },
     #     "data": {
     #         "id": "1",
     #         "type": "people"
     #         "attributes": {"name": "Alice"},
-    #         "meta": {"page": {"offset": 10}}
     #     }
     # }
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -733,7 +733,7 @@ class PolygonSchema(Schema):
     regular = fields.Boolean()
     # This is an attribute that uses the 'meta' key: /data/attributes/meta
     meta = fields.String()
-    # This is the resource object's meta object: /data/meta
+    # This is the resource object's meta object: /meta
     resource_meta = fields.Meta()
 
     class Meta:
@@ -751,10 +751,10 @@ class TestMeta(object):
                 'regular': False,
                 'meta': 'This is an ill-advised (albeit valid) attribute name.',
             },
-            'meta': {
-                'some': 'metadata',
-            },
         },
+        'meta': {
+            'some': 'metadata',
+        }
     }
 
     shape = {


### PR DESCRIPTION
Fixes #95: The meta information object should be at top level of the response data and not inside the primary data (http://jsonapi.org/format/#document-top-level and http://jsonapi.org/format/#document-meta).

Before

    {
        "data": {
            "id": "1",
            "type": "people"
            "attributes": {"name": "Alice"},
            "meta": {"page": {"offset": 10}}
        }
    }

After

    {
        "meta": {"page": {"offset": 10}},
        "data": {
            "id": "1",
            "type": "people"
            "attributes": {"name": "Alice"},
        }
    }