### PR TITLE
Fixes #45

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,3 +24,4 @@ Contributors (chronological)
 - `@mrhanky17 <https://github.com/mrhanky17>`_
 - Mark Hall `@scmmmh <https://github.com/scmmmh>`_
 - Scott Werner `@scottwernervt <https://github.com/scottwernervt>`_
+- Michael Dodsworth `@mdodsworth <https://github.com/mdodsworth>`_

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -101,7 +101,7 @@ class Relationship(BaseRelationship):
 
     @property
     def schema(self):
-        only = getattr(self, 'only', ())
+        only = getattr(self, 'only', None)
         exclude = getattr(self, 'exclude', ())
 
         if isinstance(self.__schema, SchemaABC):


### PR DESCRIPTION
In Marshmallow 2.5.1, the meaning of passing `only=()` to `BaseSchema`
changed from applying no filtering, to filtering all fields. Rather than
defaulting the value of `only` to `()`, we should be defaulting to
`None`