### PR TITLE
Document change in issue #95

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,8 @@ Changelog
 Features:
 
 * Add support for marshmallow 3 (:issue:`97`). Thanks :user:`rockmnew`.
-  Thanks :user:`mdodsworth` for helping with :issue:`101`.
+* Thanks :user:`mdodsworth` for helping with :issue:`101`.
+* Move meta information object to document top level (:issue:`95`). Thanks :user:`scottwernervt`.
 
 0.16.0 (2017-11-08)
 ===================


### PR DESCRIPTION
The changelog for v0.17.0 skipped a ticket to move the meta data into the root of the response object done in #95