### PR TITLE
Drop official support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
 - '3.6'
 - '3.5'
-- '3.4'
 - '2.7'
 - pypy
 env:
@@ -15,7 +14,7 @@ install:
 - travis_retry pip install -U marshmallow"$MARSHMALLOW_VERSION" --pre
 before_script:
 - flake8 .
-script: py.test
+script: pytest
 jobs:
   include:
   - stage: PyPI Release

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Features:
 * Add ``fields.ResourceMeta`` for serializing a resource-level meta
   object (:issue:``). Thanks :user:`scottwernervt`.
 
+Other changes:
+
+* *Backwards-incompatible*: Drop official support for Python 3.4.
+
 0.17.0 (2018-04-29)
 ===================
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -79,7 +79,7 @@ To run all tests: ::
 
     $ invoke test
 
-To run tests on Python 2.7, 3.4, and 3.5 virtual environments (must have each interpreter installed): ::
+To run tests on Python 2.7, 3.5, and 3.6 virtual environments (must have each interpreter installed): ::
 
     $ tox
 

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Full documentation is available at https://marshmallow-jsonapi.readthedocs.io/.
 Requirements
 ============
 
-- Python >= 2.7 or >= 3.4
+- Python >= 2.7 or >= 3.5
 
 Project Links
 =============

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36
+envlist=py27,py35,py36
 [flake8]
 exclude=
     .git,
@@ -11,4 +11,4 @@ deps=
     -rdev-requirements.txt
 commands=
     flake8 .
-    py.test
+    pytest


### PR DESCRIPTION
See marshmallow-code/marshmallow#804:

> 3.4 is over 4 years old, and 3.7 is around the corner.
> Let's move forward.