### PR TITLE
Relationship id_field serialization

### DIFF
--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -79,7 +79,7 @@ class Relationship(BaseRelationship):
     :param str id_field: Attribute name to pull ids from if a resource linkage is included.
     """
 
-    id_field = 'id'
+    default_id_field = 'id'
 
     def __init__(
         self,
@@ -97,10 +97,20 @@ class Relationship(BaseRelationship):
         self.many = many
         self.include_resource_linkage = include_resource_linkage
         self.include_data = False
-        self.__schema = schema
         self.type_ = type_
-        self.id_field = id_field or self.id_field
+        self.__id_field = id_field
+        self.__schema = schema
         super(Relationship, self).__init__(**kwargs)
+
+    @property
+    def id_field(self):
+        if self.__id_field:
+            return self.__id_field
+        if self.__schema:
+            field = self.schema.fields['id']
+            return field.attribute or self.default_id_field
+        else:
+            return self.default_id_field
 
     @property
     def schema(self):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -3,7 +3,8 @@ import pytest
 
 from hashlib import md5
 from marshmallow import ValidationError
-from marshmallow_jsonapi.fields import DocumentMeta, Meta, ResourceMeta, Relationship
+from marshmallow_jsonapi import Schema
+from marshmallow_jsonapi.fields import Str, DocumentMeta, Meta, ResourceMeta, Relationship
 
 
 class TestGenericRelationshipField:
@@ -76,6 +77,33 @@ class TestGenericRelationshipField:
         )
         result = field.serialize('author_id', post)
         assert result['data']['id'] == str(post.author_id)
+
+    def test_include_resource_linkage_id_field_from_string(self):
+        field = Relationship(
+            include_resource_linkage=True, type_='authors',
+            id_field='name',
+        )
+        result = field.serialize('author', {'author': {'name': 'Ray Bradbury'}})
+        assert 'data' in result
+        assert result['data']
+        assert result['data']['id'] == 'Ray Bradbury'
+
+    def test_include_resource_linkage_id_field_from_schema(self):
+        class AuthorSchema(Schema):
+            id = Str(attribute='name')
+
+            class Meta:
+                type_ = 'authors'
+                strict = True
+
+        field = Relationship(
+            include_resource_linkage=True, type_='authors',
+            schema=AuthorSchema,
+        )
+        result = field.serialize('author', {'author': {'name': 'Ray Bradbury'}})
+        assert 'data' in result
+        assert result['data']
+        assert result['data']['id'] == 'Ray Bradbury'
 
     def test_include_resource_linkage_many(self, post):
         field = Relationship(


### PR DESCRIPTION
`id_field` is now a property on the `Relationship` field and contains logic to determine what the id string is:

- user defined value
- user defined schema id field attribute
- default value of `'id'`

**backwards-incompatible**
`Relationship.id_field='id'` is now `Relationship.default_id_field='id'`. This affects users that were overriding the value before defining a relationship. For example:

```python
fields.Relationship.id_field = 'item_id'

class AuthorSchema:
   id = fields.Str()
   author = fields.Relationship(include_resource_linkage=True, type_='authors')
```

Fixes #69