### PR TITLE
Fix an error where relationships would not be properly deserialized

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,3 +25,4 @@ Contributors (chronological)
 - Mark Hall `@scmmmh <https://github.com/scmmmh>`_
 - Scott Werner `@scottwernervt <https://github.com/scottwernervt>`_
 - Michael Dodsworth `@mdodsworth <https://github.com/mdodsworth>`_
+- Robert Sawicki `@ww3pl <https://github.com/ww3pl>`_

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -190,7 +190,7 @@ class Relationship(BaseRelationship):
         # relationship. Unserialize it if we have a schema set; otherwise we
         # fall back below to old behaviour of only IDs.
         if 'attributes' in data and self.__schema:
-            result = self.schema.load({'data': data})
+            result = self.schema.load({'data': data, 'included': self.root.included_data})
             return result.data if _MARSHMALLOW_VERSION_INFO[0] < 3 else result
 
         return data.get('id')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -733,7 +733,8 @@ class TestRelationshipLoading(object):
             }
         ]
 
-        included_author = list(filter(lambda item: item['type'] == 'people', article['included']))[0]
+        included_author = filter(lambda item: item['type'] == 'people', article['included'])
+        included_author = list(included_author)[0]
 
         data = unpack(RelationshipWithSchemaArticleSchema().load(article))
         author = data['comments'][0]['author']

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -733,7 +733,7 @@ class TestRelationshipLoading(object):
             }
         ]
 
-        included_author = next(filter(lambda item: item['type'] == 'people', article['included']))
+        included_author = list(filter(lambda item: item['type'] == 'people', article['included']))[0]
 
         data = unpack(RelationshipWithSchemaArticleSchema().load(article))
         author = data['comments'][0]['author']

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -683,6 +683,64 @@ class TestRelationshipLoading(object):
         assert data['author'] == "1"
         assert data['comments'] == ["1"]
 
+    def test_deserializing_nested_relationship_fields(self):
+        class RelationshipWithSchemaCommentSchema(Schema):
+            id = fields.Str()
+            body = fields.Str(required=True)
+            author = fields.Relationship(
+                schema=AuthorSchema, many=False, type_='people'
+            )
+
+            class Meta:
+                type_ = 'comments'
+                strict = True
+
+        class RelationshipWithSchemaArticleSchema(Schema):
+            id = fields.Integer()
+            body = fields.String()
+            comments = fields.Relationship(
+                schema=RelationshipWithSchemaCommentSchema, many=True, type_='comments'
+            )
+
+            class Meta:
+                type_ = 'articles'
+                strict = True
+
+        article = self.article.copy()
+        article['included'] = [
+            {
+                "id": "1",
+                "type": "comments",
+                "attributes": {
+                    "body": "Test comment"
+                },
+                "relationships": {
+                    "author": {
+                        'data': {
+                            "type": "people",
+                            "id": "2"
+                        }
+                    }
+                }
+            },
+            {
+                'id': "2",
+                'type': "people",
+                'attributes': {
+                    "first_name": "Marshmallow Jr",
+                    "last_name": "JsonAPI"
+                }
+            }
+        ]
+
+        included_author = next(filter(lambda item: item['type'] == 'people', article['included']))
+
+        data = unpack(RelationshipWithSchemaArticleSchema().load(article))
+        author = data['comments'][0]['author']
+
+        assert isinstance(author, dict)
+        assert author['first_name'] == included_author['attributes']['first_name']
+
     def test_deserializing_relationship_errors(self):
         data = self.article
         data['data']['relationships']['author']['data'] = {}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -771,7 +771,8 @@ class TestRelationshipLoading(object):
             },
         ]
 
-        included_author = next(filter(lambda item: item['type'] == 'people', article['included']))
+        included_author = filter(lambda item: item['type'] == 'people', article['included'])
+        included_author = list(included_author)[0]
 
         data = unpack(RelationshipWithSchemaArticleSchema().load(article))
         author = data['comments'][0]['author']

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -771,8 +771,7 @@ class TestRelationshipLoading(object):
             }
         ]
 
-        included_author = filter(lambda item: item['type'] == 'people', article['included'])
-        included_author = list(included_author)[0]
+        included_author = next(filter(lambda item: item['type'] == 'people', article['included']))
 
         data = unpack(RelationshipWithSchemaArticleSchema().load(article))
         author = data['comments'][0]['author']

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -726,7 +726,7 @@ class TestRelationshipLoading(object):
             id = fields.Str()
             body = fields.Str(required=True)
             author = fields.Relationship(
-                schema=AuthorSchema, many=False, type_='people'
+                schema=AuthorSchema, many=False, type_='people',
             )
 
             class Meta:
@@ -737,7 +737,7 @@ class TestRelationshipLoading(object):
             id = fields.Integer()
             body = fields.String()
             comments = fields.Relationship(
-                schema=RelationshipWithSchemaCommentSchema, many=True, type_='comments'
+                schema=RelationshipWithSchemaCommentSchema, many=True, type_='comments',
             )
 
             class Meta:
@@ -747,28 +747,28 @@ class TestRelationshipLoading(object):
         article = self.article.copy()
         article['included'] = [
             {
-                "id": "1",
-                "type": "comments",
-                "attributes": {
-                    "body": "Test comment"
+                'id': '1',
+                'type': 'comments',
+                'attributes': {
+                    'body': 'Test comment',
                 },
-                "relationships": {
-                    "author": {
+                'relationships': {
+                    'author': {
                         'data': {
-                            "type": "people",
-                            "id": "2"
-                        }
-                    }
-                }
+                            'type': 'people',
+                            'id': '2',
+                        },
+                    },
+                },
             },
             {
-                'id': "2",
-                'type': "people",
+                'id': '2',
+                'type': 'people',
                 'attributes': {
-                    "first_name": "Marshmallow Jr",
-                    "last_name": "JsonAPI"
-                }
-            }
+                    'first_name': 'Marshmallow Jr',
+                    'last_name': 'JsonAPI',
+                },
+            },
         ]
 
         included_author = next(filter(lambda item: item['type'] == 'people', article['included']))

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -739,6 +739,9 @@ class TestRelationshipLoading(object):
             comments = fields.Relationship(
                 schema=RelationshipWithSchemaCommentSchema, many=True, type_='comments',
             )
+            author = fields.Relationship(
+                dump_only=False, include_resource_linkage=True, many=False, type_='people',
+            )
 
             class Meta:
                 type_ = 'articles'


### PR DESCRIPTION
Fix an error from issue #127  where multi-level nested relationships do not serialize as full objects, even if 'schema' parameter is passed when creating a Relationship field