### PR TITLE
Fix issue in the case where many=True but the data passed in is not a…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 *********
 
+0.20.3 (2018-09-13)
+===================
+
+Bug fixes:
+
+* Fix missing load validation when data is not a collection
+  but many=True (:pr:`161`).
+  :user:`grantHarris`.
+
 0.20.2 (2018-08-15)
 ===================
 

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -207,6 +207,13 @@ class Schema(ma.Schema):
 
         data = data['data']
         if many:
+            if not is_collection(data):
+                raise ma.ValidationError([{
+                    'detail': '`data` expected to be a collection.',
+                    'source': {
+                        'pointer': '/data',
+                    },
+                }])
             return [self.unwrap_item(each) for each in data]
         return self.unwrap_item(data)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -559,6 +559,22 @@ class TestErrorFormatting:
         assert 'source' in err
         assert err['source']['pointer'] == '/data/0/attributes/password'
 
+    def test_errors_many_not_list(self):
+        authors = make_serialized_author(
+            {'first_name': 'Dan', 'last_name': 'Gebhardt', 'password': 'bad'},
+        )
+        try:
+            errors = AuthorSchema(many=True).validate(authors)['errors']
+        except ValidationError as err:
+            errors = err.messages['errors']
+
+        assert len(errors) == 1
+
+        err = errors[0]
+        assert 'source' in err
+        assert err['source']['pointer'] == '/data'
+        assert err['detail'] == '`data` expected to be a collection.'
+
     def test_many_id_errors(self):
         """ the pointer for id should be at the data object, not attributes """
         author = {'data': [{'type': 'people', 'id': 'invalid',


### PR DESCRIPTION
This PR adds proper validation in the case of passing an object instead of a list for the `data` key when many=True.

The existing code blows up with an `string indices must be integers` exception if you accidentally pass a single item instead of a list.