### PR TITLE
Fix issue where a full url is quoted incorrectly

### DIFF
--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -429,4 +429,4 @@ class Schema(ma.Schema):
 
     def generate_url(self, link, **kwargs):
         """Generate URL with any kwargs interpolated."""
-        return quote(link.format(**kwargs)) if link else None
+        return quote(link.format(**kwargs), safe='/:?=&') if link else None

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -1,10 +1,4 @@
 # -*- coding: utf-8 -*-
-try:
-    from urllib.parse import quote
-except ImportError:
-    # Python 2.7 compatibility
-    from urllib import quote
-
 import marshmallow as ma
 from marshmallow.exceptions import ValidationError
 from marshmallow.compat import iteritems, PY2
@@ -429,4 +423,4 @@ class Schema(ma.Schema):
 
     def generate_url(self, link, **kwargs):
         """Generate URL with any kwargs interpolated."""
-        return quote(link.format(**kwargs), safe='/:?=&') if link else None
+        return link.format(**kwargs) if link else None

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -143,9 +143,9 @@ class AuthorAutoSelfLinkFirstLastSchema(AuthorAutoSelfLinkSchema):
 
     class Meta:
         type_ = 'people'
-        self_url = '/authors/{first_name} {last_name}'
+        self_url = 'http://example.com/authors/{first_name} {last_name}'
         self_url_kwargs = {'first_name': '<first_name>', 'last_name': '<last_name>'}
-        self_url_many = '/authors/'
+        self_url_many = 'http://example.com/authors/'
 
 
 class TestAutoSelfUrls:
@@ -188,7 +188,7 @@ class TestAutoSelfUrls:
     def test_self_link_quoted(self, author):
         data = unpack(AuthorAutoSelfLinkFirstLastSchema().dump(author))
         assert 'links' in data
-        assert data['links']['self'] == quote('/authors/{} {}'.format(
+        assert data['links']['self'] == 'http://example.com/authors/{}'.format(quote('{} {}'.format(
             author.first_name,
             author.last_name,
-        ))
+        )))

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,9 +1,3 @@
-try:
-    from urllib.parse import quote
-except ImportError:
-    # Python 2.7 compatibility
-    from urllib import quote
-
 import pytest
 from marshmallow import validate, ValidationError
 
@@ -184,11 +178,3 @@ class TestAutoSelfUrls:
         assert first['type'] == 'comments'
 
         assert 'links' not in data
-
-    def test_self_link_quoted(self, author):
-        data = unpack(AuthorAutoSelfLinkFirstLastSchema().dump(author))
-        assert 'links' in data
-        assert data['links']['self'] == 'http://example.com/authors/{}'.format(quote('{} {}'.format(
-            author.first_name,
-            author.last_name,
-        )))


### PR DESCRIPTION
This Pr fixes an issue reported where a full URL is quoted incorrectly. See https://github.com/marshmallow-code/marshmallow-jsonapi/issues/171