### PR TITLE
Relationship deserialization

### DIFF
--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -7,12 +7,12 @@ import warnings
 
 from marshmallow.compat import basestring
 
-from marshmallow import ValidationError, class_registry, missing
+from marshmallow import ValidationError, class_registry
 from marshmallow.fields import Field
 # Make core fields importable from marshmallow_jsonapi
 from marshmallow.fields import *  # noqa
 from marshmallow.base import SchemaABC
-from marshmallow.utils import is_collection
+from marshmallow.utils import is_collection, missing as missing_
 
 from .utils import get_value, resolve_params, iteritems, _MARSHMALLOW_VERSION_INFO
 
@@ -214,10 +214,12 @@ class Relationship(BaseRelationship):
             value does not contain a `data` key, and if the value is
             required but unspecified.
         """
+        if value is missing_:
+            return super(Relationship, self).deserialize(value, attr, data)
         if not isinstance(value, dict) or 'data' not in value:
             # a relationships object does not need 'data' if 'links' is present
             if value and 'links' in value:
-                return missing
+                return missing_
             else:
                 raise ValidationError('Must include a `data` key')
         return super(Relationship, self).deserialize(value['data'], attr, data)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -7,6 +7,7 @@ from marshmallow.fields import Int
 
 from marshmallow_jsonapi import Schema
 from marshmallow_jsonapi.fields import Str, DocumentMeta, Meta, ResourceMeta, Relationship
+from marshmallow_jsonapi.utils import _MARSHMALLOW_VERSION_INFO
 
 
 class TestGenericRelationshipField:
@@ -254,6 +255,10 @@ class TestGenericRelationshipField:
             field.deserialize({})
         assert excinfo.value.args[0] == 'Must include a `data` key'
 
+    @pytest.mark.skipif(
+        _MARSHMALLOW_VERSION_INFO[0] < 3,
+        reason='deserialize does not handle missing skeleton',
+    )
     def test_deserialize_missing(self):
         field = Relationship(
             related_url='/posts/{post_id}/comments',
@@ -263,6 +268,10 @@ class TestGenericRelationshipField:
         result = field.deserialize(missing_)
         assert result is missing_
 
+    @pytest.mark.skipif(
+        _MARSHMALLOW_VERSION_INFO[0] < 3,
+        reason='deserialize does not handle missing skeleton',
+    )
     def test_deserialize_missing_with_missing_param(self):
         field = Relationship(
             related_url='/posts/{post_id}/comments',

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -221,7 +221,7 @@ class TestGenericRelationshipField:
         result = field.deserialize({'data': []})
         assert result == []
 
-    def test_deserialize_empty_data_node(self):
+    def test_deserialize_empty_data(self):
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'},
@@ -233,7 +233,7 @@ class TestGenericRelationshipField:
             'Must have an `id` field', 'Must have a `type` field',
         ]
 
-    def test_deserialize_required(self):
+    def test_deserialize_required_missing(self):
         field = Relationship(
             related_url='/posts/{post_id}/comments',
             related_url_kwargs={'post_id': '<id>'}, required=True,
@@ -271,16 +271,6 @@ class TestGenericRelationshipField:
         )
         result = field.deserialize(missing_)
         assert result == 'value'
-
-    def test_deserialize_missing_relationship_node(self):
-        field = Relationship(
-            related_url='/posts/{post_id}/comments',
-            related_url_kwargs={'post_id': '<id>'},
-            many=False, include_resource_linkage=True, type_='comments',
-        )
-        with pytest.raises(ValidationError) as excinfo:
-            field.deserialize(missing_)
-        assert excinfo.value.args[0] == 'Must include a `data` key'
 
     def test_deserialize_many_non_list_relationship(self):
         field = Relationship(many=True, include_resource_linkage=True, type_='comments')
@@ -368,7 +358,9 @@ class TestGenericRelationshipField:
             field.deserialize({'data': {'type': 'authors', 'id': 'not_a_number'}})
         assert excinfo.value.args[0] == 'Not a valid integer.'
 
+
 class TestMetaField:
+
     def test_deprecation(self):
         with pytest.warns(DeprecationWarning, match='deprecated'):
             Meta()


### PR DESCRIPTION
- Fixes #177 by using marshmallow Field deserialize method to handle required, allow_none, and missing checks (missing attribute was never called for relationships).
- Dropped `test_deserialize_missing_relationship_node` because it shouldn't throw a `ValidationError` if field is not required and missing from the input.
- Some tests are skipped for `marshmallow < 3` due to handling of `field.deserialize`: [2.x-line](https://github.com/marshmallow-code/marshmallow/blob/2.x-line/marshmallow/fields.py#L262) vs [dev](https://github.com/marshmallow-code/marshmallow/blob/dev/marshmallow/fields.py#L277-L279)

