### PR TITLE
Fixed 'data' key in relationship being set to empty array when the value is None

### DIFF
--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -249,9 +249,7 @@ class Relationship(BaseRelationship):
 
         # resource linkage is required when including the data
         if self.include_resource_linkage or self.include_data:
-            if value is None:
-                ret['data'] = [] if self.many else None
-            else:
+            if not value is None:
                 ret['data'] = self.get_resource_linkage(value)
 
         if self.include_data and value is not None:

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -249,6 +249,8 @@ class Relationship(BaseRelationship):
 
         # resource linkage is required when including the data
         if self.include_resource_linkage or self.include_data:
+            if not self.many and value is None:
+                ret['data'] = None
             if value is not None:
                 ret['data'] = self.get_resource_linkage(value)
 

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -249,7 +249,7 @@ class Relationship(BaseRelationship):
 
         # resource linkage is required when including the data
         if self.include_resource_linkage or self.include_data:
-            if not value is None:
+            if value is not None:
                 ret['data'] = self.get_resource_linkage(value)
 
         if self.include_data and value is not None:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -301,7 +301,7 @@ class TestGenericRelationshipField:
         )
         result = field.serialize('author', post_with_null_author)
         assert result and result['links']['related']
-        assert result['data'] is None
+        assert 'data' not in result
 
     def test_include_null_data_many(self, post_with_null_comment):
         field = Relationship(

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -301,7 +301,7 @@ class TestGenericRelationshipField:
         )
         result = field.serialize('author', post_with_null_author)
         assert result and result['links']['related']
-        assert 'data' not in result
+        assert result['data'] is None
 
     def test_include_null_data_many(self, post_with_null_comment):
         field = Relationship(


### PR DESCRIPTION
The data key should be ommited if a property value is equal to `None`. It's [not required as described in the spec](https://jsonapi.org/format/#document-resource-object-relationships). Logically, if an empty array is desired in the JSON rather than ommiting the `data` key completely, you could assign an empty python array. e.g. `self.comments = []`.

Currently  `self.comments = []` and `self.comments = None` renders the exact same JSON response: `[]`. This is problematic for relationships where you only occasionally want to include side-loaded data in compound documents. Most JS libraries (Ember.js is what I'm using) would intepret `[]` as an empty set, not requiring an additional HTTP request.

**Example:**
```python
class User:
    def __init__(self, data, included_data = []):
        self.id = data['id']
        self.name = data['name']
        self.comments = None

       if 'comments' in included_data:
           # Query db to load more comments
           self.comments = # ....

# Schema class definition ommited  
# ...
comments = fields.Relationship(
    related_url='/user/{id}/comments',
    related_url_kwargs={'id': '<id>'},
    many=True, include_resource_linkage=True,
    type_='comments',
    schema='CommentSchema'
)
```