### PR TITLE
Uses format_map when building a link

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,3 +29,4 @@ Contributors (chronological)
 - Grant Harris `@grantHarris <https://github.com/grantHarris>`_
 - Robert Sawicki `@ww3pl <https://github.com/ww3pl>`_
 - `@aberres <https://github.com/aberres>`_
+- George Alton `@georgealton <https://github.com/georgealton>`_

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -418,4 +418,4 @@ class Schema(ma.Schema):
 
     def generate_url(self, link, **kwargs):
         """Generate URL with any kwargs interpolated."""
-        return link.format(**kwargs) if link else None
+        return link.format_map(kwargs) if link else None


### PR DESCRIPTION
This changes uses the `format_map` to format the link string rather than unpacking `kwargs` and copying it. 