### PR TITLE
Add include_data=True option for including all relationships

### DIFF
--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -74,7 +74,10 @@ class Schema(ma.Schema):
     def __init__(self, *args, **kwargs):
         self.include_data = kwargs.pop("include_data", ())
         super().__init__(*args, **kwargs)
-        if self.include_data:
+
+        if self.include_data is True:
+            self.include_all_data()
+        elif self.include_data:
             self.check_relations(self.include_data)
 
         if not self.opts.type_:
@@ -92,6 +95,15 @@ class Schema(ma.Schema):
         self.document_meta = {}
 
     OPTIONS_CLASS = SchemaOpts
+
+    def include_all_data(self):
+        """
+        Recursively set include_data for all relationships to this schema
+        """
+        for field in self.fields.values():
+            if isinstance(field, BaseRelationship):
+                field.include_data = True
+                field.schema.include_all_data()
 
     def check_relations(self, relations):
         """Recursive function which checks if a relation is valid."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -149,6 +149,17 @@ class TestCompoundDocuments:
         }
         assert included_comments_author_ids == expected_comments_author_ids
 
+    def test_include_data_auto_all(self, post):
+        """
+        Test that we can use include_data=True to include all relations recursively
+        """
+        data = unpack(PostSchema(include_data=True).dump(post))
+        assert "included" in data
+        assert len(data["included"]) == 8
+        for included in data["included"]:
+            assert included["id"]
+            assert included["type"] in ("people", "comments", "keywords")
+
     def test_include_no_data(self, post):
         data = unpack(PostSchema(include_data=()).dump(post))
         assert "included" not in data


### PR DESCRIPTION
Closes #263. 

One thing I'd like feedback on is the actual interface here. You could argue that `include_data=True` isn't elegant, so I'd be open to something like `include_data='all'` or `include_data='*'`.