### PR TITLE
Fix included_data and data["included"] type consistency.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,3 +30,4 @@ Contributors (chronological)
 - Robert Sawicki `@ww3pl <https://github.com/ww3pl>`_
 - `@aberres <https://github.com/aberres>`_
 - George Alton `@georgealton <https://github.com/georgealton>`_
+- Adrian Vandier Ast `@AdrianVandierAst <https://github.com/AdrianVandierAst>`_

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -201,7 +201,7 @@ class Relationship(BaseRelationship):
         # fall back below to old behaviour of only IDs.
         if "attributes" in data and self.__schema:
             result = self.schema.load(
-                {"data": data, "included": self.root.included_data}
+                {"data": data, "included": self.root.included_data.values()}
             )
             return result.data if _MARSHMALLOW_VERSION_INFO[0] < 3 else result
 

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -270,14 +270,14 @@ class Schema(ma.Schema):
                         }
                     ]
                 )
-            included_data[(item["type"], str(item["id"]))] = item
+            included_data[(item["type"], item["id"])] = item
         return included_data
 
     def _extract_from_included(self, data):
         """Extract included data matching the item in ``data``.
         """
         return self.included_data.get(
-            (data["type"], str(data["id"])), {"type": data["type"], "id": data["id"]}
+            (data["type"], data["id"]), {"type": data["type"], "id": data["id"]}
         )
 
     def inflect(self, text):

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -166,19 +166,18 @@ class Schema(ma.Schema):
             # Fold included data related to this relationship into the item, so
             # that we can deserialize the whole objects instead of just IDs.
             if self.included_data:
-                included_data = []
+                included_data = None
                 inner_data = value.get("data", [])
 
                 # Data may be ``None`` (for empty relationships), but we only
                 # need to process it when it's present.
                 if inner_data:
                     if not is_collection(inner_data):
-                        included_data = next(
-                            self._extract_from_included(inner_data), None
-                        )
+                        included_data = self._extract_from_included(inner_data)
                     else:
+                        included_data = []
                         for data in inner_data:
-                            included_data.extend(self._extract_from_included(data))
+                            included_data.append(self._extract_from_included(data))
 
                 if included_data:
                     value["data"] = included_data
@@ -235,7 +234,7 @@ class Schema(ma.Schema):
         # Store this on the instance so we have access to the included data
         # when processing relationships (``included`` is outside of the
         # ``data``).
-        self.included_data = data.get("included", {})
+        self.included_data = self._load_included_data(data.get("included", []))
         self.document_meta = data.get("meta", {})
 
         try:
@@ -257,16 +256,28 @@ class Schema(ma.Schema):
                 return data, formatted_messages
         return result
 
-    def _extract_from_included(self, data):
-        """Extract included data matching the items in ``data``.
-
-        For each item in ``data``, extract the full data from the included
-        data.
+    def _load_included_data(self, included):
+        """ Transform a list of resource object into a dict indexed by object type and id.
         """
-        return (
-            item
-            for item in self.included_data
-            if item["type"] == data["type"] and str(item["id"]) == str(data["id"])
+        included_data = {}
+        for item in included:
+            if "type" not in item.keys() or "id" not in item.keys():
+                raise ma.ValidationError(
+                    [
+                        {
+                            "detail": "`included` objects must include `type` and `id` keys.",
+                            "source": {"pointer": "/included"},
+                        }
+                    ]
+                )
+            included_data[(item["type"], str(item["id"]))] = item
+        return included_data
+
+    def _extract_from_included(self, data):
+        """Extract included data matching the item in ``data``.
+        """
+        return self.included_data.get(
+            (data["type"], str(data["id"])), {"type": data["type"], "id": data["id"]}
         )
 
     def inflect(self, text):

--- a/tests/base.py
+++ b/tests/base.py
@@ -92,6 +92,7 @@ class CommentSchema(Schema):
         related_url_kwargs={"id": "<id>"},
         schema=AuthorSchema,
         many=False,
+        type_="people",
     )
 
     class Meta:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -385,8 +385,10 @@ class TestCompoundDocuments:
                 {
                     "type": "people",
                     "id": "1",
-                    "first_name": fake.first_name(),
-                    "last_name": fake.last_name(),
+                    "attributes": {
+                        "first_name": fake.first_name(),
+                        "last_name": fake.last_name(),
+                    },
                 }
             ],
         }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -391,9 +391,9 @@ class TestCompoundDocuments:
             ],
         }
         schema = CommentSchema()
-        data = schema.load(json_data)
+        data = unpack(schema.load(json_data))
         comment = Comment(**data)
-        out_json_data = schema.dump(comment)
+        out_json_data = unpack(schema.dump(comment))
         assert json_data["included"] == out_json_data["included"]
 
 


### PR DESCRIPTION
The included resource objects in the json api are in a list but the schema implementation
needs it to be a dict indexed by type and id.
The new test checks that loading and then dumping with the same schema object on a
dict with an included resource works. It is needed for Flask-rest-jsonapi that re-uses schema between load and dump.