### PR TITLE
Improve link generation performance of included resource

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,3 +30,4 @@ Contributors (chronological)
 - Robert Sawicki `@ww3pl <https://github.com/ww3pl>`_
 - `@aberres <https://github.com/aberres>`_
 - George Alton `@georgealton <https://github.com/georgealton>`_
+- Areeb Jamal `@iamareebjamal <https://github.com/iamareebjamal>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,12 +2,18 @@
 Changelog
 *********
 
+0.23.0 (unreleased)
+===================
+
+* Improve performance of link generation from `Relationship` (:issue:`277`).
+  Thanks :user:`iamareebjamal` for reporting and fixing.
+
 0.22.0 (2019-09-15)
 ===================
 
 Deprecation/Removals:
 
-* Drop support for Python 2.7 and 3.6.
+* Drop support for Python 2.7 and 3.5.
   Only Python>=3.6 is supported (:issue:`251`).
 * Drop support for marshmallow 3 pre-releases. Only stable versions >=2.15.2 are supported.
 * Remove ``fields.Meta``.

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -243,7 +243,7 @@ class Relationship(BaseRelationship):
         if self.include_resource_linkage or self.include_data:
             return super().serialize(attr, obj, accessor)
         return self._serialize(None, attr, obj)
-    
+
     def _serialize(self, value, attr, obj):
         dict_class = self.parent.dict_class if self.parent else dict
 

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -239,6 +239,11 @@ class Relationship(BaseRelationship):
             raise ValidationError("Relationship is not list-like")
         return self.extract_value(value)
 
+    def serialize(self, attr, obj, accessor=None):
+        if self.include_resource_linkage or self.include_data:
+            return super().serialize(attr, obj, accessor)
+        return self._serialize(None, attr, obj)
+    
     def _serialize(self, value, attr, obj):
         dict_class = self.parent.dict_class if self.parent else dict
 

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -239,6 +239,10 @@ class Relationship(BaseRelationship):
             raise ValidationError("Relationship is not list-like")
         return self.extract_value(value)
 
+    # We have to override serialize because we don't want those fields
+    # to be serialized which are related to the resource but not included
+    # in the request. And we don't have enough control in _serialize
+    # to prevent their serialization
     def serialize(self, attr, obj, accessor=None):
         if self.include_resource_linkage or self.include_data:
             return super().serialize(attr, obj, accessor)


### PR DESCRIPTION
Improves performance of link generation from `Relationship` field 
by not fetching the related resource if include query is not made.
This cuts down on the unneeded database queries to objects which are
not needed in the final dump

Fixes #277