### PR TITLE
Fix schema with relationship to dump None

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ _sandbox
 env
 venv
 .python-version
+
+# IDE
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,3 @@ _sandbox
 env
 venv
 .python-version
-
-# IDE
-.idea/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Deprecations/Removals:
 
 * Drop support for marshmallow 2, which is now EOL (:pr:`332`).
 
+Bug fixes:
+
+* Fix behavior when serializing ``None`` (:pr:`302`). Thanks :user:`mahenzon`.
+
 Other changes:
 
 * Test against Python 3.8 and 3.9 (:pr:`332`).

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -244,7 +244,7 @@ class Relationship(BaseRelationship):
     # in the request. And we don't have enough control in _serialize
     # to prevent their serialization
     def serialize(self, attr, obj, accessor=None):
-        if self.include_resource_linkage or self.include_data:
+        if obj is None or self.include_resource_linkage or self.include_data:
             return super().serialize(attr, obj, accessor)
         return self._serialize(None, attr, obj)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -98,6 +98,10 @@ class TestResponseFormatting:
         assert data["data"] is None
         assert "links" not in data
 
+    def test_schema_with_relationship_processes_none(self):
+        data = unpack(CommentSchema().dump(None))
+        assert data == {"data": None}
+
     def test_dump_empty_list(self):
         data = unpack(AuthorSchema(many=True).dump([]))
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -97,7 +97,7 @@ class TestResponseFormatting:
         assert "links" not in data
 
     def test_schema_with_relationship_processes_none(self):
-        data = unpack(CommentSchema().dump(None))
+        data = CommentSchema().dump(None)
         assert data == {"data": None}
 
     def test_dump_empty_list(self):


### PR DESCRIPTION
Caused by #278

When `None` is passed to a schema, which contains relationships, it fails. Though on the previous versions it successfully returned data. That's because of direct use of `self._serialize`. The check for missing fields just doesn't happen.

If you try to run the new test, it will fail with this text:

```
=================================== FAILURES ===================================
_____ TestResponseFormatting.test_schema_with_relationship_processes_none ______

self = <tests.test_schema.TestResponseFormatting object at 0x7f5ede746278>

    def test_schema_with_relationship_processes_none(self):
>       data = unpack(CommentSchema().dump(None))

test_schema.py:103: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../venv/lib/python3.6/site-packages/marshmallow/schema.py:553: in dump
    result = self._serialize(processed_obj, many=many)
../venv/lib/python3.6/site-packages/marshmallow/schema.py:517: in _serialize
    value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)
../marshmallow_jsonapi/fields.py:249: in serialize
    return self._serialize(None, attr, obj)
../marshmallow_jsonapi/fields.py:256: in _serialize
    related_url = self.get_related_url(obj)
../marshmallow_jsonapi/fields.py:155: in get_related_url
    params = resolve_params(obj, self.related_url_kwargs, default=self.default)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

obj = None, params = {'id': '<id>'}, default = <marshmallow.missing>

    def resolve_params(obj, params, default=missing):
        """Given a dictionary of keyword arguments, return the same dictionary except with
        values enclosed in `< >` resolved to attributes on `obj`.
        """
        param_values = {}
        for name, attr_tpl in params.items():
            attr_name = tpl(str(attr_tpl))
            if attr_name:
                attribute_value = get_value(obj, attr_name, default=default)
                if attribute_value is not missing:
                    param_values[name] = attribute_value
                else:
                    raise AttributeError(
                        "{attr_name!r} is not a valid "
>                       "attribute of {obj!r}".format(attr_name=attr_name, obj=obj)
                    )
E                   AttributeError: 'id' is not a valid attribute of None

../marshmallow_jsonapi/utils.py:55: AttributeError
============================== 1 failed in 0.25s ===============================
```