### PR TITLE
Support for polymorphic relationships

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,3 +33,4 @@ Contributors (chronological)
 - Areeb Jamal `@iamareebjamal <https://github.com/iamareebjamal>`_
 - Suren Khorenyan `@mahenzon <https://github.com/mahenzon>`_
 - Karthikeyan Singaravelan `@tirkarthi <https://github.com/tirkarthi>`_
+- Max Buck `@buckmaxwell <https://github.com/buckmaxwell>`_

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -135,20 +135,20 @@ To serialize links, pass a URL format string and a dictionary of keyword argumen
     #     }
     # }
 
-It is possible to create a polymorphic relationship by having the serialized model define type_. Polymorphic relationships are supported by json-api and by many front end frameworks that implement it like `ember <https://guides.emberjs.com/release/models/relationships/#toc_polymorphism>`_.
+It is possible to create a polymorphic relationship by having the serialized model define __jsonapi_type__. Polymorphic relationships are supported by json-api and by many front end frameworks that implement it like `ember <https://guides.emberjs.com/release/models/relationships/#toc_polymorphism>`_.
 
 .. code-block:: python
 
     class PaymentMethod(Bunch):
-        type_ = "payment-methods"
+        __jsonapi_type__ = "payment-methods"
 
 
     class PaymentMethodCreditCard(PaymentMethod, Bunch):
-        type_ = "payment-methods-cc"
+        __jsonapi_type__ = "payment-methods-cc"
 
 
     class PaymentMethodPaypal(PaymentMethod, Bunch):
-        type_ = "payment-methods-paypal"
+        __jsonapi_type__ = "payment-methods-paypal"
 
 
     class User:
@@ -186,7 +186,7 @@ A polymorphic Schema can be created using `OneOfSchema <https://github.com/marsh
 
         def get_obj_type(self, obj):
             if isinstance(obj, PaymentMethod):
-                return obj.type_
+                return obj.__jsonapi_type__
             else:
                 raise Exception("Unknown object type: {}".format(obj.__class__.__name__))
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -135,9 +135,10 @@ To serialize links, pass a URL format string and a dictionary of keyword argumen
     #     }
     # }
 
-It is possible to create a polymorphic relationship by having the serialized model define type_. Polymorphic relationships are supported by json-api and by many front end frameworks that implement it like `ember <https://guides.emberjs.com/release/models/relationships/#toc_polymorphism>`
+It is possible to create a polymorphic relationship by having the serialized model define type_. Polymorphic relationships are supported by json-api and by many front end frameworks that implement it like `ember <https://guides.emberjs.com/release/models/relationships/#toc_polymorphism>`_.
 
 .. code-block:: python
+
     class PaymentMethod(Bunch):
         type_ = "payment-methods"
 
@@ -155,9 +156,11 @@ It is possible to create a polymorphic relationship by having the serialized mod
             self.id = id
             self.payment_methods = get_payment_methods(id)
 
-A polymorphic Schema can be created using `OneOfSchema <https://github.com/marshmallow-code/marshmallow-oneofschema>`. For example, a user may have multiple payment methods with slightly different attributes. Note that OneOfSchema must be separately installed and that there are other ways of creating a polymorphic Schema, this is merely an example. 
+A polymorphic Schema can be created using `OneOfSchema <https://github.com/marshmallow-code/marshmallow-oneofschema>`_. For example, a user may have multiple payment methods with slightly different attributes. Note that OneOfSchema must be separately installed and that there are other ways of creating a polymorphic Schema, this is merely an example. 
+
 
 .. code-block:: python
+
     class PaymentMethodCreditCardSchema(Schema):
         id = fields.Str()
         last_4 = fields.Str()

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -173,12 +173,12 @@ class Relationship(BaseRelationship):
     def get_resource_linkage(self, value):
         if self.many:
             resource_object = [
-                {"type": self.type_, "id": _stringify(self._get_id(each))}
+                {"type": self._get_type(each), "id": _stringify(self._get_id(each))}
                 for each in value
             ]
         else:
             resource_object = {
-                "type": self.type_,
+                "type": self._get_type(value),
                 "id": _stringify(self._get_id(value)),
             }
         return resource_object
@@ -288,6 +288,12 @@ class Relationship(BaseRelationship):
             return self.schema.get_attribute(value, self.id_field, value)
         else:
             return get_value(value, self.id_field, value)
+
+    def _get_type(self, obj):
+        try:
+            return obj.type_
+        except AttributeError:
+            return self.type_
 
 
 class DocumentMeta(Field):

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -61,7 +61,7 @@ class Relationship(BaseRelationship):
 
     This field is read-only by default.
 
-    The type_ keyword argument will be ignored in favor of a type_ attribute on the serialized
+    The type_ keyword argument will be ignored in favor of a __jsonapi_type__ attribute on the serialized
     resource. This allows support for polymorphic relationships.
 
     :param str related_url: Format string for related resource links.
@@ -294,7 +294,7 @@ class Relationship(BaseRelationship):
 
     def _get_type(self, obj):
         try:
-            return obj.type_
+            return obj.__jsonapi_type__
         except AttributeError:
             return self.type_
 

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -61,6 +61,9 @@ class Relationship(BaseRelationship):
 
     This field is read-only by default.
 
+    The type_ keyword argument will be ignored in favor of a type_ attribute on the serialized
+    resource. This allows support for polymorphic relationships.
+
     :param str related_url: Format string for related resource links.
     :param dict related_url_kwargs: Replacement fields for `related_url`. String arguments
         enclosed in `< >` will be interpreted as attributes to pull from the target object.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,13 @@ from setuptools import setup, find_packages
 
 INSTALL_REQUIRES = ("marshmallow>=2.15.2",)
 EXTRAS_REQUIRE = {
-    "tests": ["pytest", "mock", "faker==4.18.0", "Flask==1.1.2"],
+    "tests": [
+        "pytest",
+        "mock",
+        "faker==4.18.0",
+        "Flask==1.1.2",
+        "marshmallow-oneofschema==2.1.0",
+    ],
     "lint": ["flake8==3.8.4", "flake8-bugbear==20.11.1", "pre-commit~=2.0"],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]

--- a/tests/base.py
+++ b/tests/base.py
@@ -4,6 +4,7 @@ from faker import Factory
 from marshmallow import validate
 
 from marshmallow_jsonapi import Schema, fields
+from marshmallow_oneofschema import OneOfSchema
 
 fake = Factory.create()
 
@@ -28,6 +29,76 @@ class Comment(Bunch):
 
 class Keyword(Bunch):
     pass
+
+
+class User(Bunch):
+    pass
+
+
+class PaymentMethod(Bunch):
+    """Base Class for Payment Methods"""
+
+    type_ = "payment-methods"
+
+
+class PaymentMethodCreditCard(PaymentMethod, Bunch):
+    type_ = "payment-methods-cc"
+
+
+class PaymentMethodPaypal(PaymentMethod, Bunch):
+    type_ = "payment-methods-paypal"
+
+
+class PaymentMethodCreditCardSchema(Schema):
+    id = fields.Str()
+    last_4 = fields.Str()
+
+    class Meta:
+        type_ = "payment-methods-cc"
+
+
+class PaymentMethodPaypalSchema(Schema):
+    id = fields.Str()
+    linked_email = fields.Str()
+
+    class Meta:
+        type_ = "payment-methods-paypal"
+
+
+class PaymentMethodSchema(Schema, OneOfSchema):
+    """Using https://github.com/marshmallow-code/marshmallow-oneofschema is one way to have a polymorphic schema"""
+
+    id = fields.Str()
+
+    type_schemas = {
+        "payment-methods-cc": PaymentMethodCreditCardSchema,
+        "payment-methods-paypal": PaymentMethodPaypalSchema,
+    }
+
+    def get_obj_type(self, obj):
+        if isinstance(obj, PaymentMethod):
+            return obj.type_
+        else:
+            raise Exception(f"Unknown object type: {obj.__class__.__name__}")
+
+    class Meta:
+        type_ = "payment-methods"
+
+
+class UserSchema(Schema):
+    id = fields.Str()
+    first_name = fields.Str(required=True)
+    last_name = fields.Str(required=True)
+
+    payment_methods = fields.Relationship(
+        schema=PaymentMethodSchema,
+        include_resource_linkage=True,
+        many=True,
+        type_="payment-methods",
+    )
+
+    class Meta:
+        type_ = "users"
 
 
 class AuthorSchema(Schema):

--- a/tests/base.py
+++ b/tests/base.py
@@ -38,15 +38,15 @@ class User(Bunch):
 class PaymentMethod(Bunch):
     """Base Class for Payment Methods"""
 
-    type_ = "payment-methods"
+    __jsonapi_type__ = "payment-methods"
 
 
 class PaymentMethodCreditCard(PaymentMethod, Bunch):
-    type_ = "payment-methods-cc"
+    __jsonapi_type__ = "payment-methods-cc"
 
 
 class PaymentMethodPaypal(PaymentMethod, Bunch):
-    type_ = "payment-methods-paypal"
+    __jsonapi_type__ = "payment-methods-paypal"
 
 
 class PaymentMethodCreditCardSchema(Schema):
@@ -77,7 +77,7 @@ class PaymentMethodSchema(Schema, OneOfSchema):
 
     def get_obj_type(self, obj):
         if isinstance(obj, PaymentMethod):
-            return obj.type_
+            return obj.__jsonapi_type__
         else:
             raise Exception(f"Unknown object type: {obj.__class__.__name__}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,15 @@
 import pytest
 
-from tests.base import Author, Post, Comment, Keyword, fake
+from tests.base import (
+    Author,
+    Post,
+    Comment,
+    Keyword,
+    User,
+    PaymentMethodCreditCard,
+    PaymentMethodPaypal,
+    fake,
+)
 
 
 def make_author():
@@ -33,6 +42,32 @@ def make_comment(with_author=True):
 
 def make_keyword():
     return Keyword(keyword=fake.domain_word())
+
+
+def make_payment_methods():
+    return [
+        PaymentMethodCreditCard(id=fake.random_int(), last_4="1335"),
+        PaymentMethodPaypal(id=fake.random_int(), linked_email="gal@example.com"),
+    ]
+
+
+def make_user():
+    return User(
+        id=fake.random_int(),
+        first_name=fake.first_name(),
+        last_name=fake.last_name(),
+        payment_methods=make_payment_methods(),
+    )
+
+
+@pytest.fixture()
+def user():
+    return make_user()
+
+
+@pytest.fixture()
+def payment_methods():
+    return make_payment_methods()
 
 
 @pytest.fixture()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -81,13 +81,13 @@ class TestResponseFormatting:
             0
         ]
         assert first_payment_method["id"] == str(user.payment_methods[0].id)
-        assert first_payment_method["type"] == user.payment_methods[0].type_
+        assert first_payment_method["type"] == user.payment_methods[0].__jsonapi_type__
 
         second_payment_method = data["data"]["relationships"]["payment_methods"][
             "data"
         ][1]
         assert second_payment_method["id"] == str(user.payment_methods[1].id)
-        assert second_payment_method["type"] == user.payment_methods[1].type_
+        assert second_payment_method["type"] == user.payment_methods[1].__jsonapi_type__
 
         included_resources = data["included"]
         assert (

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -10,6 +10,7 @@ from tests.base import (
     PostSchema,
     PolygonSchema,
     ArticleSchema,
+    UserSchema,
 )
 
 
@@ -70,6 +71,33 @@ class TestResponseFormatting:
 
         assert attribs["first_name"] == authors[0].first_name
         assert attribs["last_name"] == authors[0].last_name
+
+    def test_dump_single_with_polymorphic_relationship(self, user):
+        data = UserSchema(include_data=("payment_methods",)).dump(user)
+        assert "data" in data
+        assert type(data["data"]["relationships"]["payment_methods"]["data"]) is list
+
+        first_payment_method = data["data"]["relationships"]["payment_methods"]["data"][
+            0
+        ]
+        assert first_payment_method["id"] == str(user.payment_methods[0].id)
+        assert first_payment_method["type"] == user.payment_methods[0].type_
+
+        second_payment_method = data["data"]["relationships"]["payment_methods"][
+            "data"
+        ][1]
+        assert second_payment_method["id"] == str(user.payment_methods[1].id)
+        assert second_payment_method["type"] == user.payment_methods[1].type_
+
+        included_resources = data["included"]
+        assert (
+            included_resources[0]["attributes"]["last_4"]
+            == user.payment_methods[0].last_4
+        )
+        assert (
+            included_resources[1]["attributes"]["linked_email"]
+            == user.payment_methods[1].linked_email
+        )
 
     def test_self_link_single(self, author):
         data = AuthorSchema().dump(author)
@@ -149,6 +177,15 @@ class TestCompoundDocuments:
             if i["type"] == "people" and i["id"] != str(post.author.id)
         }
         assert included_comments_author_ids == expected_comments_author_ids
+
+    def test_include_data_with_polymorphic_relation(self, user):
+        data = UserSchema(include_data=("payment_methods",)).dump(user)
+
+        assert "included" in data
+        assert len(data["included"]) == 2
+        for included in data["included"]:
+            assert included["id"]
+            assert included["type"] in ("payment-methods-cc", "payment-methods-paypal")
 
     def test_include_no_data(self, post):
         data = PostSchema(include_data=()).dump(post)


### PR DESCRIPTION
It is desirable to be able to include a collection of resources that may inherit from one type, but have different types. This is both supported by the JSON API spec, and by many front end frameworks that implement it like ember which provides [this excellent use case](https://guides.emberjs.com/release/models/relationships/#toc_polymorphism).

The change here is to allow for users to define a type_ attribute on the serialized instance that takes preference over a type defined with the type_ key. This results in no behavior changes for existing functionality, and should be considered backward compatible.

Thank you everyone for you work on this; I am making use of this library and am a big fan.