### PR TITLE
Fix attribute name inflection

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,3 +33,4 @@ Contributors (chronological)
 - Areeb Jamal `@iamareebjamal <https://github.com/iamareebjamal>`_
 - Suren Khorenyan `@mahenzon <https://github.com/mahenzon>`_
 - Karthikeyan Singaravelan `@tirkarthi <https://github.com/tirkarthi>`_
+- Jannik Bamberger `@JBamberger <https://github.com/JBamberger>`_

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -216,7 +216,7 @@ class Schema(ma.Schema):
 
     def on_bind_field(self, field_name, field_obj):
         """Schema hook override. When binding fields, set ``data_key`` to the inflected form of field_name."""
-        if not field_obj.data_key:
+        if not field_obj.data_key and not field_name == "id":
             field_obj.data_key = self.inflect(field_name)
         return None
 
@@ -321,7 +321,7 @@ class Schema(ma.Schema):
             # JSONAPI identifier is a special field that exists above the attribute object.
             pointer.append("attributes")
 
-        pointer.append(self.inflect(field_name))
+        pointer.append(field_name)
 
         if relationship:
             pointer.append("data")
@@ -363,11 +363,11 @@ class Schema(ma.Schema):
                 if value:
                     if "relationships" not in ret:
                         ret["relationships"] = self.dict_class()
-                    ret["relationships"][self.inflect(field_name)] = value
+                    ret["relationships"][field_name] = value
             else:
                 if "attributes" not in ret:
                     ret["attributes"] = self.dict_class()
-                ret["attributes"][self.inflect(field_name)] = value
+                ret["attributes"][field_name] = value
 
         links = self.get_resource_links(item)
         if links:


### PR DESCRIPTION
The attribute name inflection function is applied multiple times to some attributes. For simple inflection functions this works, because they reach a fixpoint after the first application, e.g. the dasherize function does nothing if the attribute is already dasherized.

For other functions, like adding a postfix, this does not work, i.e. for `lambda s: s + '_x'` would result in an attribute name `username_x_x` for an attribute called `username`. Expected would be `username_x`.

Furthermore, the inflection is applied to the id field, even though, the id field name is dictated by the jsonapi standard. Thus, the predefined fields should not be affected by inflection.

A quick test with the `meta` showed, that this problem does not occur here, but other such predefined fields might still be affected by the inflection.